### PR TITLE
Modify Search API endpoints, default boolean behavior

### DIFF
--- a/routes/search.js
+++ b/routes/search.js
@@ -56,13 +56,16 @@ module.exports = function (app) {
       params["queries"].map((term) => {
         switch(term['field']){
           case "author":
-            body.query("match", "entities.name", term['value'])
+            body.query("query_string", {"fields": ["entities.name"], "query": term["value"], "default_operator": "and"})
             break
           case "keyword":
-            body.query("query_string", 'query', term['value'])
+            body.query("query_string", 'query', term['value'], {"default_operator": "and"})
+            break
+          case "subject":
+            body.query('query_string', {"fields": ["subjects.subject"], "query": term["value"], "default_operator": "and"})
             break
           default:
-            body.query('match', term['field'], term['value'])
+            body.query('query_string', {"fields": [term["field"]], "query": term["value"], "default_operator": "and"})
             break
         }
       })


### PR DESCRIPTION
The front-end application is behaving in unexpected ways when returning exact match search results due to non-standard implementation of boolean search. At present the search API will default to using an OR operator to join search terms. This update changes that default operator to AND, which more closely matches most users' conceptions of standard search.

This also standardizes all search types to use `query_string` searches, which allow for a fully functional set of AND, OR and quoted search terms, allowing strings such as `Brazil OR "South America"` to be passed as a query with expected results received. 