### PR TITLE
LCNAF/VIAF lookup

### DIFF
--- a/routes/v2/search.js
+++ b/routes/v2/search.js
@@ -57,6 +57,19 @@ const simpleSearch = (params, app) => {
         )
       )
       break
+    case 'lcnaf':
+    case 'viaf':
+      body.query('bool', b => b
+        .query('bool', c => c
+          .orQuery('nested', { path: 'agents'}, (q) => {
+            return q.query('term', `agents.${field}`, queryTerm)  
+          })
+          .orQuery('nested', { path: 'instances.agents'}, (q) => {
+            return q.query('term', `instances.agents.${field}`, queryTerm)  
+          })
+        )
+      )
+      break
     case 'subject':
       body.query('nested', { path: 'subjects', query: { query_string: { query: queryTerm, default_operator: 'and' } } })
       break

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -6,7 +6,7 @@
     "description": "REST API for Elasticsearch index for the ResearchNow Project"
   },
   "host": "platform.nypl.org",
-  "basePath": "/api",
+  "basePath": "/api/v0.1/research-now",
   "schemes": [
     "http",
     "https"
@@ -18,7 +18,7 @@
     }
   ],
   "paths": {
-    "/v0.1/sfr/work": {
+    "/sfr/work": {
       "get": {
         "tags": [
           "research-now"
@@ -74,7 +74,7 @@
         }
       }
     },
-    "/v0.1/sfr/works": {
+    "/sfr/works": {
       "get": {
         "tags": [
           "research-now"

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -312,7 +312,7 @@
             "description": "Field to query. Currently supports: Keyword, Title, Author and Subject. Defaults to Keyword",
             "required": true,
             "type": "string",
-            "enum": ["keyword", "title", "author", "subject"]
+            "enum": ["keyword", "title", "author", "subject", "viaf", "lcnaf"]
           },{
             "name": "query",
             "in": "query",


### PR DESCRIPTION
This implements `lcnaf` and `viaf` as `field` options in the `v2` search endpoint. These authority files provide unique identifiers to agent and allow for precise lookups of authors, etc. and their related works. 

The query itself is straightforward, it looks for agents associated with either a work or its child instances and if found returns that work. This enables better lookups of related works from detail pages and should also support stronger agent filters when implemented.

As a minor update this also includes a change to the swagger documentation where the `basePath` was incorrectly set, preventing the documented endpoints from functioning properly.