### PR TITLE
SFR-396 Implement search filtering and aggregations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ config/local.json
 package-lock.json
 node_modules
 dist
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/lib/search.js
+++ b/lib/search.js
@@ -31,6 +31,7 @@ class Search {
         .then((resp) => {
           if (this.reverseResult) resp.hits.hits.reverse()
           Search.formatResponsePaging(resp)
+          Search.formatResponseFacets(resp)
           resolve(resp)
         })
         .catch(error => reject(error))
@@ -43,7 +44,7 @@ class Search {
    * The prev_page_sort and next_page_sort arrays can be passed as parameters
    * to retrieve the next or previous page.
    *
-   * @param {Object} ElasticSearch search response object
+   * @param {Object} resp ElasticSearch search response object
    */
   static formatResponsePaging(resp) {
     if (resp.hits.hits.length) {
@@ -55,6 +56,33 @@ class Search {
         next_page_sort: lastSort,
       }
     }
+  }
+
+  /**
+   * Parses the aggregation object returned as part of the ElasticSearch
+   * response into an object containing arrays of values for each facet. These
+   * can be displayed used to help refine results. The format of the facets
+   * object consists of a key that labels the facet with an array of
+   * value/count pairs that display each value for the groupings along with the
+   * total number of matching results in the full response object.
+   *
+   * @param {Object} resp ElasticSearch search response object
+   */
+  static formatResponseFacets(resp) {
+    const facets = {}
+    Object.keys(resp.aggregations).forEach((agg) => {
+      const items = []
+      const curAgg = resp.aggregations[agg]
+      curAgg[agg].buckets.forEach((bucket) => {
+        items.push({ value: bucket.key, count: bucket[agg].doc_count })
+      })
+      items.sort((a, b) => b.count - a.count)
+      facets[agg] = items
+    })
+    /* eslint-disable no-param-reassign */
+    resp.facets = facets
+    delete resp.aggregations
+    /* eslint-enable no-param-reassign */
   }
 
   /**
@@ -168,7 +196,6 @@ class Search {
     }
 
     const { field, query } = this.params
-
     this.query = bodybuilder()
 
     // Catch case where escape character has been escaped and reduce to a single escape character
@@ -213,27 +240,7 @@ class Search {
         break
     }
     this.queryCount = this.query.build()
-
-    // Filter block, used to search/filter data on specific terms. This can serve
-    // as the main search field (useful for browsing) but generally it narrows
-    // results in conjunction with a query
-    if ('filters' in this.params && this.params.filters instanceof Array) {
-      // eslint-disable-next-line array-callback-return
-      this.params.filters.map((filter) => {
-        switch (filter.field) {
-          case 'year':
-            this.query.query('nested', { path: 'instances', query: { range: { 'instances.pub_date': { gte: filter.value, lte: filter.value } } } })
-            break
-          case 'language':
-            this.query.query('nested', { path: 'language', query: { term: { 'language.language': filter.value } } })
-            this.query.query('nested', { path: 'instances.language', query: { term: { 'instances.language.language': filter.value } } })
-            break
-          default:
-            this.logger('Not configured to handle this filter, ignoring')
-            break
-        }
-      })
-    }
+    this.addFilters()
 
     // Sort block, this orders the results. Can be asc/desc and on any field
     if ('sort' in this.params && this.params.sort instanceof Array) {
@@ -258,17 +265,50 @@ class Search {
         { uuid: 'asc' },
       ])
     }
+    this.addAggregations()
+  }
 
-    // Aggregations block, this should be more complicated to enable full features
-    // but essentially this builds an object of record counts grouped by a term
-    // For example it can group works by authors/agents. This is used to
-    // display browse options and do other metrics related querying
-    if ('aggregations' in this.params && this.params.aggregations instanceof Array) {
+  /**
+   * Generates a filter block to create or a refine a search. Generally this
+   * accepts a field from one of the search filter facets, but can be used
+   * to generate a set of browse results as well.
+   *
+   * Due to the construction of the ElasticSearch documents, each filter must
+   * be custom defined here to ensure proper discovery and refinement.
+   */
+  addFilters() {
+    if ('filters' in this.params && this.params.filters instanceof Array) {
       // eslint-disable-next-line array-callback-return
-      this.params.aggregations.map((agg) => {
-        this.query.aggregation(agg.type, agg.field)
+      this.params.filters.map((filter) => {
+        switch (filter.field) {
+          case 'year':
+            this.query.query('nested', { path: 'instances', query: { range: { 'instances.pub_date': { gte: filter.value, lte: filter.value } } } })
+            break
+          case 'language':
+            this.query.query('nested', { path: 'language', query: { term: { 'language.language': filter.value } } })
+            this.query.query('nested', { path: 'instances.language', query: { term: { 'instances.language.language': filter.value } } })
+            break
+          default:
+            this.logger.warning('API Not configured to handle this filter')
+            break
+        }
       })
     }
+  }
+
+  /**
+   * Add aggregations to all search results. These are used to display filter
+   * facets in the search result page and allow users to refine their searches
+   *
+   * Filters/facet display is all unfiform, but aggregation creation is
+   * specific to each field and must be custom-defined within this method
+   */
+  addAggregations() {
+    // Add aggregation for language facet
+    const langFacet = 'language'
+    this.query.agg('nested', { path: 'language' }, langFacet, a => a.agg('terms', 'language.language'))
+
+    this.query.agg('nested', { path: 'instances.language' }, langFacet, a => a.agg('terms', 'instances.language.language', langFacet, b => b.agg('reverse_nested', {}, langFacet)))
   }
 }
 

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -441,9 +441,84 @@
           }
         }
       }
+    },
+    "/v0.1/research-now/viaf-lookup": {
+      "get": {
+        "tags": [
+          "research-now"
+        ],
+        "summary": "Looks up agent names in the OCLC VIAF API",
+        "description": "Queries the OCLC VIAF API for agent records, including a controlled version of the agent's name along with VIAF and LCNAF IDs. These responses are cached in a Redis cluster for faster responses to known agents.",
+        "parameters": [
+          {
+            "name": "queryName",
+            "in": "query",
+            "description": "Name of agent to query in VIAF API. Can be an individual or organization.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON object containing a response in the body parameter, in a serialized JSON string.",
+            "schema": {
+              "$ref": "#/definitions/VIAFResultResponse"
+            }
+          },
+          "404": {
+            "description": "A message stating that a matching VIAF record could not be found.",
+            "schema": {
+              "$ref": "#/definitions/VIAFResultResponse"
+            }
+          },
+          "500": {
+            "description": "Indicates that an error was encountered in VIAF API, Redis cluster, or other upstream service.",
+            "schema": {
+              "$ref": "#/definitions/VIAFResultResponse"
+            }
+          },
+          "502": {
+            "description": "An internal server error, either in the Lambda function or the API Gateway integration",
+            "schema": {
+              "$ref": "#/definitions/VIAFResultResponse"
+            }
+          },
+          "504": {
+            "description": "A malformed response was received from the Lambda function.",
+            "schema": {
+              "$ref": "#/definitions/VIAFResultResponse"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
+    "VIAFResultResponse": {
+      "type": "object",
+      "properties": {
+        "statusCode": {
+          "type": "integer"
+        },
+        "header": {
+          "$ref": "#/definitions/VIAFHeader"
+        },
+        "body": {
+          "type": "string"
+        },
+        "isBase64Encoded": {
+          "type": "boolean"
+        }
+      }
+    },
+    "VIAFHeader": {
+      "type": "object",
+      "properties": {
+        "req-time": {
+          "type": "number"
+        }
+      }
+    },
     "ResultResponse": {
       "type": "object",
       "properties": {
@@ -522,12 +597,6 @@
             "$ref": "#/definitions/SortBlock"
           }
         },
-        "aggregations": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AggregationBlock"
-          }
-        },
         "per_page": {
           "description": "Results to return per page. Defaults to 10",
           "example": 10,
@@ -579,12 +648,6 @@
             "$ref": "#/definitions/SortBlock"
           }
         },
-        "aggregations": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AggregationBlock"
-          }
-        },
         "per_page": {
           "description": "Results to return per page. Defaults to 10",
           "example": 10,
@@ -594,22 +657,6 @@
           "description": "The page of results to return. By default the results will be sorted by the ElasticSearch sorting algorithm",
           "example": 0,
           "type": "integer"
-        }
-      }
-    },
-    "AggregationBlock": {
-      "title": "Aggregation",
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "example": "terms",
-          "description": "Type of aggregation to run, most frequently 'terms'"
-        },
-        "field": {
-          "type": "string",
-          "example": "entities.name.keyword",
-          "description": "Field to run aggregation on"
         }
       }
     },
@@ -641,7 +688,7 @@
         },
         "value": {
           "type": "string",
-          "example": "it",
+          "example": "English",
           "description": "Value on which to filter. Can be a string (for term filters), or an object such as {'gte': 2000} for years"
         }
       }

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -2,20 +2,23 @@
 const chai = require('chai')
 const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
+const bodybuilder = require('bodybuilder')
 
 chai.should()
 chai.use(sinonChai)
 const { expect } = chai
 
-const { simpleSearch } = require('../routes/v2/search')
+const { Search } = require('../lib/search')
 const { MissingParamError } = require('../lib/errors')
 
 describe('v2 simple search tests', () => {
-  it('should raise an error if field or query is missing', async (done) => {
+  it('should raise an error if field or query is missing in build', (done) => {
+    const testApp = sinon.stub()
     const params = {
       field: 'testing',
     }
-    expect(simpleSearch.bind(simpleSearch, params, 'app')).to.throw(MissingParamError('Your POST request must include either queries or filters'))
+    const testSearch = new Search(testApp, params)
+    expect(testSearch.buildSearch.bind()).to.throw(MissingParamError('Your POST request must include either queries or filters'))
     done()
   })
 
@@ -30,12 +33,13 @@ describe('v2 simple search tests', () => {
         hits: [
           {
             _index: 'sfr_test',
-            _type: 'teest',
+            _type: 'test',
             _id: 1,
             _score: 1,
           },
         ],
       },
+      aggregations: {},
     })
     const testApp = {
       client: {
@@ -46,8 +50,55 @@ describe('v2 simple search tests', () => {
       field: 'test',
       query: 'testing',
     }
-    const resp = await simpleSearch(params, testApp)
+    const testSearch = new Search(testApp, params)
+    testSearch.query = {
+      build: sinon.stub(),
+    }
+
+    const resp = await testSearch.execSearch()
     expect(resp.took).to.equal(0)
     expect(resp.hits.hits.length).to.equal(1)
+  })
+
+  it('should create facet object for response', (done) => {
+    const testResp = {
+      aggregations: {
+        test: {
+          test: {
+            buckets: [
+              {
+                key: 'test1',
+                test: { doc_count: 9 },
+              },
+              {
+                key: 'test2',
+                test: { doc_count: 3 },
+              },
+              {
+                key: 'test3',
+                test: { doc_count: 6 },
+              },
+            ],
+          },
+        },
+      },
+    }
+
+    Search.formatResponseFacets(testResp)
+    expect(testResp.facets.test.length).to.equal(3)
+    expect(testResp.facets.test[1].value, 'test3')
+    done()
+  })
+
+  it('should add aggregations for queries', (done) => {
+    const testApp = sinon.mock()
+    const testSearch = new Search(testApp, {})
+    testSearch.query = bodybuilder()
+    testSearch.addAggregations()
+    testBody = testSearch.query.build()
+    expect(testBody).to.have.property('aggs')
+    expect(testBody.aggs).to.have.property('language')
+    expect(testBody.aggs.language).to.have.property('nested')
+    done()
   })
 })


### PR DESCRIPTION
This implements new functionality for the `v2` `POST` search endpoint. The aggregation will always be available regardless if a filter is set.

- It enables `filters` which is an array of objects containing `field` and `value` strings. These filter down the current search query and return only the results that match the filter. Example:
```
filters: [{
  "field": "language",
  "value": "English"
}]
```
- It enables `aggregations` which return sums of matching result groupings. At present the only supported aggregation is for languages, which is automatically returned with search results. Each aggregation is identified by a `key` and contains an array of objects with `value` and `count` properties. The facet values are sorted by default in descending order by `count`. Example response:
```
facets: {
  "language": [
    {
      "value": "English",
      "count": 10
    },{
      "value": "Spanish",
      "count": 8
    }
  ]
}
```

Additionally this extends the Swagger documentation to include the necessary parameter, and test cases were improved to cover the new functionality. 