### PR TITLE
SFR-383 Add blacklisted agent roles to search API

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -1,15 +1,18 @@
 const bodybuilder = require('bodybuilder')
 const { MissingParamError } = require('./errors')
 
-const blacklistRoles = ['publisher', 'printer', 'consultant', 'funder',
-  'honoree', 'arl', 'sponsor', 'thesis advisor', 'engraver', 'engineer',
-  'copyright holder', 'host institution', 'court reporter', 'inscriber',
-  'printer of plates', 'donor', 'binding designer', 'typographer', 'performer',
-  'binder', 'presenter', 'retager', 'collector', 'producer', 'expert',
-  'former owner', 'secretary', 'contractor', 'production company', 'proofreader',
-  'woodcutter', 'electrotyper', 'publishing director', 'transcriber',
-  'stereotyper', 'bookseller', 'book producer', 'corrector', 'dedicatee',
-  'printmaker', 'patron', 'other', 'book designer', 'imprint',
+/*
+ * Array of roles to exclude from author queries
+ */
+const blacklistRoles = ['arl', 'binder', 'binding designer', 'book designer',
+  'book producer', 'bookseller', 'collector', 'consultant', 'contractor',
+  'corrector', 'dedicatee', 'donor', 'copyright holder', 'court reporter',
+  'electrotyper', 'engineer', 'engraver', 'expert', 'former owner', 'funder',
+  'honoree', 'host institution', 'imprint', 'inscriber', 'other', 'patron',
+  'performer', 'presenter', 'producer', 'production company', 'publisher',
+  'printer', 'printer of plates', 'printmaker', 'proofreader',
+  'publishing director', 'retager', 'secretary', 'sponsor', 'stereotyper',
+  'thesis advisor', 'transcriber', 'typographer', 'woodcutter',
 ]
 
 /** Class representing a search object. */

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,6 +1,17 @@
 const bodybuilder = require('bodybuilder')
 const { MissingParamError } = require('./errors')
 
+const blacklistRoles = ['publisher', 'printer', 'consultant', 'funder',
+  'honoree', 'arl', 'sponsor', 'thesis advisor', 'engraver', 'engineer',
+  'copyright holder', 'host institution', 'court reporter', 'inscriber',
+  'printer of plates', 'donor', 'binding designer', 'typographer', 'performer',
+  'binder', 'presenter', 'retager', 'collector', 'producer', 'expert',
+  'former owner', 'secretary', 'contractor', 'production company', 'proofreader',
+  'woodcutter', 'electrotyper', 'publishing director', 'transcriber',
+  'stereotyper', 'bookseller', 'book producer', 'corrector', 'dedicatee',
+  'printmaker', 'patron', 'other', 'book designer', 'imprint',
+]
+
 /** Class representing a search object. */
 class Search {
   /**
@@ -205,8 +216,32 @@ class Search {
       case 'author':
         this.query.query('bool', b => b
           .query('bool', c => c
-            .orQuery('nested', { path: 'agents', query: { query_string: { query: queryTerm, default_operator: 'and' } } })
-            .orQuery('nested', { path: 'instances.agents', query: { query_string: { query: queryTerm, default_operator: 'and' } } })))
+            .orQuery('nested', {
+              path: 'agents',
+              query: {
+                bool: {
+                  must: {
+                    query_string: { query: queryTerm, default_operator: 'and' },
+                  },
+                  must_not: {
+                    terms: { 'agents.roles': blacklistRoles },
+                  },
+                },
+              },
+            })
+            .orQuery('nested', {
+              path: 'instances.agents',
+              query: {
+                bool: {
+                  must: {
+                    query_string: { query: queryTerm, default_operator: 'and' },
+                  },
+                  must_not: {
+                    terms: { 'instances.agents.roles': blacklistRoles },
+                  },
+                },
+              },
+            })))
         break
       case 'lcnaf':
       case 'viaf':


### PR DESCRIPTION
This commit adds an array of blacklisted agent roles to the search API, specifically the `author` endpoint. These roles (such as `publisher` and `imprint`) are associated withthe production of the book, not its writing/creation. Users generally do not expect to see results for a publisher of a book if they've executed an author search, and this prevents that confusion.

This treats the concept of `author` in a fairly broad way. It includes agents with relationships such as `illustrator` and `editor` as `author`s as they contribute to the intellectual content of a work. If further terms need to be added to the blacklist this can be easily done, but it seems best to leave this is a general sense for the time being.

This was implemented using a nested `must_not` query, which adds some complexity to the `author` endpoint, but hopefully the relatively straightforward structure of the ElasticSearch query object makes this clear.