### PR TITLE
SFR 488 Title Sorting

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -363,18 +363,31 @@ class Search {
         break
     }
     this.queryCount = this.query.build()
-    this.addFilters()
 
-    // Sort block, this orders the results. Can be asc/desc and on any field
+    this.addFilters()
+    this.addSort()
+    this.addAggregations()
+  }
+
+  /**
+   * Generates an array of sort options, allowing for a multifaceted set of
+   * sorts. While generally only one sort option will be provided, this supports
+   * an array of sorts to enable fine-grained sorting of results.
+   *
+   * Each object in the sort parameter should have a "field" and an (optional)
+   * "dir" which can be set to ASC or DESC.
+   */
+  addSort() {
     if ('sort' in this.params && this.params.sort instanceof Array) {
-      // eslint-disable-next-line array-callback-return
       const sorts = []
       this.params.sort.forEach((sort) => {
-        const sortField = sort.field
-        const { dir } = sort
+        const { field, dir } = sort
         switch (field) {
+          case 'title':
+            sorts.push({ 'title.keyword': dir || 'ASC' })
+            break
           default:
-            sorts.push({ [sortField]: dir })
+            sorts.push({ [field]: dir || 'ASC' })
         }
       })
 
@@ -388,7 +401,6 @@ class Search {
         { uuid: 'asc' },
       ])
     }
-    this.addAggregations()
   }
 
   /**

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -666,8 +666,9 @@
       "properties": {
         "field": {
           "type": "string",
-          "example": "title.keyword",
-          "description": "An ElasticSearch field to sort results by"
+          "example": "title",
+          "description": "An ElasticSearch field to sort results by",
+          "enum": ["title"]
         },
         "dir": {
           "type": "string",

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -183,4 +183,44 @@ describe('v2 simple search tests', () => {
     expect(order).to.equal(-1)
     done()
   })
+
+  it('should a title.keyword sort for a title sort option', (done) => {
+    const testApp = sinon.mock()
+    const testParams = { sort: [{ field: 'title' }] }
+    const testSearch = new Search(testApp, testParams)
+    testSearch.query = bodybuilder()
+    testSearch.addSort()
+    testBody = testSearch.query.build()
+    expect(testBody).to.have.property('sort')
+    expect(testBody.sort[0]).to.have.property('title.keyword')
+    expect(testBody.sort[0]['title.keyword'].order).to.equal('ASC')
+    expect(testBody.sort[1]).to.have.property('uuid')
+    done()
+  })
+
+  it('should add a field sort for an arbitrary sort option', (done) => {
+    const testApp = sinon.mock()
+    const testParams = { sort: [{ field: 'testing', dir: 'DESC' }] }
+    const testSearch = new Search(testApp, testParams)
+    testSearch.query = bodybuilder()
+    testSearch.addSort()
+    testBody = testSearch.query.build()
+    expect(testBody).to.have.property('sort')
+    expect(testBody.sort[0]).to.have.property('testing')
+    expect(testBody.sort[0].testing.order).to.equal('DESC')
+    expect(testBody.sort[1]).to.have.property('uuid')
+    done()
+  })
+
+  it('sort should default to _score and uuid', (done) => {
+    const testApp = sinon.mock()
+    const testSearch = new Search(testApp, {})
+    testSearch.query = bodybuilder()
+    testSearch.addSort()
+    testBody = testSearch.query.build()
+    expect(testBody).to.have.property('sort')
+    expect(testBody.sort[0]).to.have.property('_score')
+    expect(testBody.sort[1]).to.have.property('uuid')
+    done()
+  })
 })


### PR DESCRIPTION
This verifies that the search API is able to sort results based on title and adds some improvements to the sort functionality in the `Search` class:

- Refactors the sort funcionality into the `addSort` method
- Ensures that `title` sorts are made on the `title.keyword` field which is faster and removes the need to pass additional parameters to enable sorting
- Adds unit tests surrounding this functionality, fully covering the new method
- Improves the Swagger documentation, explicitly noting that `title` is the only currently enabled sort field