### PR TITLE
SFR-480 Enable years filter

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -403,14 +403,21 @@ class Search {
     if ('filters' in this.params && this.params.filters instanceof Array) {
       // eslint-disable-next-line array-callback-return
       this.params.filters.map((filter) => {
-        switch (filter.field) {
-          case 'year':
-            this.query.query('nested', { path: 'instances', query: { range: { 'instances.pub_date': { gte: filter.value, lte: filter.value } } } })
+        const { field, value } = filter
+        switch (field) {
+          case 'years':
+            this.logger.debug(`Filtering works by years ${value.start} to ${value.end}`)
+            // eslint-disable-next-line no-case-declarations
+            const dateRange = {}
+            if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
+            if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
+            this.query.query('nested', { path: 'instances', query: { range: { 'instances.pub_date': dateRange } } })
             break
           case 'language':
+            this.logger.debug(`Filtering works by language ${value}`)
             this.query.query('bool', a => a
-              .orQuery('nested', { path: 'language', query: { term: { 'language.language': filter.value } } })
-              .orQuery('nested', { path: 'instances.language', query: { term: { 'instances.language.language': filter.value } } }))
+              .orQuery('nested', { path: 'language', query: { term: { 'language.language': value } } })
+              .orQuery('nested', { path: 'instances.language', query: { term: { 'instances.language.language': value } } }))
             break
           default:
             this.logger.warning('API Not configured to handle this filter')

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "v2.2",
+    "version": "v0.2.3",
     "title": "ResearchNow Search API",
     "description": "REST API for Elasticsearch index for the ResearchNow Project"
   },
@@ -684,12 +684,14 @@
         "field": {
           "type": "string",
           "example": "language",
+          "enum": ["language", "years"],
           "description": "Field on which to match results by (effectively exact-match search)"
         },
         "value": {
-          "type": "string",
+          "type": "object",
+          "$ref": "#/definitions/FilterObject",
           "example": "English",
-          "description": "Value on which to filter. Can be a string (for term filters), or an object such as {'gte': 2000} for years"
+          "description": "Value on which to filter. Can be a string (for term filters), or an object such as {gte: 1900, lte: 2000} for years"
         }
       }
     },
@@ -708,6 +710,7 @@
           "description": "Query value"
         }
       }
-    }
+    },
+    "FilterObject": {}
   }
 }

--- a/test/swaggerDocs.test.js
+++ b/test/swaggerDocs.test.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-undef */
+require('dotenv').config()
+const request = require('supertest')
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+
+chai.should()
+chai.use(sinonChai)
+const { expect } = chai
+
+describe('Testing Swagger Documentation', () => {
+  let server
+  let req
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    server = require('../app.js')
+    req = request(server)
+  })
+  afterEach(() => {
+    server.close()
+  })
+
+  it('test Swagger docs for well formed-ness', async () => {
+    req.get('/research-now/swagger-test')
+      .expect(200)
+      .then((resp) => {
+        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.2.3')
+      })
+  })
+
+  it('should return all paths in swagger docs', async () => {
+    req.get('/research-now/swagger')
+      .expect(200)
+      .then((resp) => {
+        const apiPaths = []
+        Object.keys(resp.body.paths).map(path => apiPaths.push(path))
+        expect(apiPaths.length).to.equal(5)
+      })
+  })
+})


### PR DESCRIPTION
This fully implements the `years` filter on publication dates. There was a stub part of the `appFilters` method that was not completely implemented for the purposes of this application. This adds the ability to accurately filter results based off a range of years. This accepts a `start` year, `end` year or both, allowing users to get things before, after, or between their supplied year(s). Similar to the edition year range parsing, this enforces GMT time for all provided years to ensure accurate results are returned.

This also adds unit test for the `addFilters` method as well as integration tests for the swagger documentation (verifying their validity and version number)