### PR TITLE
Move edition_range value to within the _source object

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -111,8 +111,8 @@ class Search {
       const startYear = this.getEditionRangeValue(hit, 'gte', 1)
       const endYear = this.getEditionRangeValue(hit, 'lte', -1)
 
-      // eslint-disable-next-line no-param-reassign
-      hit.edition_range = `${startYear} - ${endYear}`
+      // eslint-disable-next-line no-param-reassign, no-underscore-dangle
+      hit._source.edition_range = `${startYear} - ${endYear}`
     })
   }
 

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -120,12 +120,14 @@ describe('v2 simple search tests', () => {
             _type: 'test',
             _id: 1,
             _score: 1,
+            _source: {},
           },
         ],
       },
     }
     Search.formatResponseEditionRange(testResp)
-    expect(testResp.hits.hits[0].edition_range).to.equal('1900 - 2000')
+    // eslint-disable-next-line no-underscore-dangle
+    expect(testResp.hits.hits[0]._source.edition_range).to.equal('1900 - 2000')
     stubGetRange.restore()
     done()
   })


### PR DESCRIPTION
This moves the calculated `edition_range` value to within the returned `_source` object. This object contains all of the metadata contained by a `Work`. Prior to this the `edition_range` values were being included in the main `hit` body, which generally contains metadata describing the `Work` record and as a result was confusing semantically. This should provide a more logical place to find this data and make for easier parsing of results in the front-end application