### PR TITLE
Add edition_range field to work responses and refactor

### DIFF
--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -1,0 +1,85 @@
+/**
+ * Generates a year range for the publication dates of the editions associated
+ * with a specific work.
+ *
+ * @param {Object} resp ElasticSearch response object
+ */
+const formatResponseEditionRange = (resp) => {
+  resp.hits.hits.forEach((hit) => {
+    const startYear = module.exports.getEditionRangeValue(hit, 'gte', 1)
+    const endYear = module.exports.getEditionRangeValue(hit, 'lte', -1)
+
+    // eslint-disable-next-line no-param-reassign, no-underscore-dangle
+    hit._source.edition_range = `${startYear} - ${endYear}`
+  })
+}
+
+/**
+ * Parses the provided Work object's editions for publication dates and returns
+ * either the earliest or latest year. If not found, will return '???' for
+ * display.
+ *
+ * @param {Object} hit Work object from the ElasticSearch response
+ * @param {String} range Either 'lte' or 'gte' for the start or end of a range
+ * @param {Number} flip Either 1 or -1 to flip the sorting to ASC or DESC.
+ *
+ * @returns {String} A 4-digit representation of the year found, else ????
+ */
+const getEditionRangeValue = (hit, range, flip) => {
+  let year
+  // eslint-disable-next-line no-underscore-dangle
+  const rangeInstance = hit._source.instances.sort(
+    module.exports.startEndCompare(range, flip),
+  ).filter(instance => instance.pub_date)[0]
+  if (rangeInstance) {
+    year = new Date(`${rangeInstance.pub_date[range]}T12:00:00.000+00:00`).getFullYear()
+  } else {
+    year = '????'
+  }
+  // eslint-disable-next-line no-restricted-globals
+  if (isNaN(year)) { year = '????' }
+  return year
+}
+
+/**
+ * Generates a custom search function that can be customized to meet the needs
+ * of the publication date fields. Handling cases when either the full date
+ * is missing from an edition record or if one part of the date range is not
+ * present.
+ *
+ * @param {String} startEnd Either 'lte' or 'gte' for the start and end of a range
+ * @param {Number} sortFlip Either 1 or -1 to flip the sort order
+ *
+ * @returns {Function} dateComparison Function to be used by the sort method
+ */
+const startEndCompare = (startEnd, sortFlip) => {
+  /**
+   * Custom implementation of a sort method to handle different cases of publication
+   * dates associated with edition records. The dates are appended with Noon GMT
+   * to ensure that no timezone issues are encountered in retrieving the year.
+   *
+   * @param {Object} a Edition object for sorting
+   * @param {Object} b Edition object for sorting
+   *
+   * @returns {Number} The sort order of the two objects, either -1, 0, or 1
+   */
+  const dateComparison = (a, b) => {
+    if (!a.pub_date && !b.pub_date) return 0
+    if (!a.pub_date) return -1 * sortFlip
+    if (!b.pub_date) return 1 * sortFlip
+
+    if (!a.pub_date[startEnd] && !b.pub_date[startEnd]) return 0
+    if (!a.pub_date[startEnd]) return -1 * sortFlip
+    if (!b.pub_date[startEnd]) return 1 * sortFlip
+
+    const d1 = new Date(`${a.pub_date[startEnd]}T12:00:00.000+00:00`).getFullYear()
+    const d2 = new Date(`${b.pub_date[startEnd]}T12:00:00.000+00:00`).getFullYear()
+
+    if (d1 > d2) return 1 * sortFlip
+    if (d1 < d2) return -1 * sortFlip
+    return 0
+  }
+  return dateComparison
+}
+
+module.exports = { formatResponseEditionRange, getEditionRangeValue, startEndCompare }

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,5 +1,6 @@
 const bodybuilder = require('bodybuilder')
 const { MissingParamError } = require('./errors')
+const Helpers = require('../helpers/esSourceHelpers')
 
 /*
  * Array of roles to exclude from author queries
@@ -46,7 +47,7 @@ class Search {
           if (this.reverseResult) resp.hits.hits.reverse()
           Search.formatResponsePaging(resp)
           Search.formatResponseFacets(resp)
-          Search.formatResponseEditionRange(resp)
+          Helpers.formatResponseEditionRange(resp)
           resolve(resp)
         })
         .catch(error => reject(error))
@@ -98,90 +99,6 @@ class Search {
     resp.facets = facets
     delete resp.aggregations
     /* eslint-enable no-param-reassign */
-  }
-
-  /**
-   * Generates a year range for the publication dates of the editions associated
-   * with a specific work.
-   *
-   * @param {Object} resp ElasticSearch response object
-   */
-  static formatResponseEditionRange(resp) {
-    resp.hits.hits.forEach((hit) => {
-      const startYear = this.getEditionRangeValue(hit, 'gte', 1)
-      const endYear = this.getEditionRangeValue(hit, 'lte', -1)
-
-      // eslint-disable-next-line no-param-reassign, no-underscore-dangle
-      hit._source.edition_range = `${startYear} - ${endYear}`
-    })
-  }
-
-  /**
-   * Parses the provided Work object's editions for publication dates and returns
-   * either the earliest or latest year. If not found, will return '???' for
-   * display.
-   *
-   * @param {Object} hit Work object from the ElasticSearch response
-   * @param {String} range Either 'lte' or 'gte' for the start or end of a range
-   * @param {Number} flip Either 1 or -1 to flip the sorting to ASC or DESC.
-   *
-   * @returns {String} A 4-digit representation of the year found, else ????
-   */
-  static getEditionRangeValue(hit, range, flip) {
-    let year
-    // eslint-disable-next-line no-underscore-dangle
-    const rangeInstance = hit._source.instances.sort(
-      this.startEndCompare(range, flip),
-    ).filter(instance => instance.pub_date)[0]
-    if (rangeInstance) {
-      year = new Date(`${rangeInstance.pub_date[range]}T12:00:00.000+00:00`).getFullYear()
-    } else {
-      year = '????'
-    }
-    // eslint-disable-next-line no-restricted-globals
-    if (isNaN(year)) { year = '????' }
-    return year
-  }
-
-  /**
-   * Generates a custom search function that can be customized to meet the needs
-   * of the publication date fields. Handling cases when either the full date
-   * is missing from an edition record or if one part of the date range is not
-   * present.
-   *
-   * @param {String} startEnd Either 'lte' or 'gte' for the start and end of a range
-   * @param {Number} sortFlip Either 1 or -1 to flip the sort order
-   *
-   * @returns {Function} dateComparison Function to be used by the sort method
-   */
-  static startEndCompare(startEnd, sortFlip) {
-    /**
-     * Custom implementation of a sort method to handle different cases of publication
-     * dates associated with edition records. The dates are appended with Noon GMT
-     * to ensure that no timezone issues are encountered in retrieving the year.
-     *
-     * @param {Object} a Edition object for sorting
-     * @param {Object} b Edition object for sorting
-     *
-     * @returns {Number} The sort order of the two objects, either -1, 0, or 1
-     */
-    const dateComparison = (a, b) => {
-      if (!a.pub_date && !b.pub_date) return 0
-      if (!a.pub_date) return -1 * sortFlip
-      if (!b.pub_date) return 1 * sortFlip
-
-      if (!a.pub_date[startEnd] && !b.pub_date[startEnd]) return 0
-      if (!a.pub_date[startEnd]) return -1 * sortFlip
-      if (!b.pub_date[startEnd]) return 1 * sortFlip
-
-      const d1 = new Date(`${a.pub_date[startEnd]}T12:00:00.000+00:00`).getFullYear()
-      const d2 = new Date(`${b.pub_date[startEnd]}T12:00:00.000+00:00`).getFullYear()
-
-      if (d1 > d2) return 1 * sortFlip
-      if (d1 < d2) return -1 * sortFlip
-      return 0
-    }
-    return dateComparison
   }
 
   /**

--- a/routes/v2/work.js
+++ b/routes/v2/work.js
@@ -1,4 +1,5 @@
 const bodybuilder = require('bodybuilder')
+const Helpers = require('../../helpers/esSourceHelpers')
 const { ElasticSearchError, MissingParamError } = require('../../lib/errors')
 
 const workEndpoints = (app, respond, handleError) => {
@@ -52,6 +53,7 @@ const fetchWork = (params, app) => {
         const respCount = resp.hits.hits.length
         if (respCount < 1) reject(new ElasticSearchError('Could not locate a record with that identifier'))
         else if (respCount > 1) reject(new ElasticSearchError('Returned multiple records, identifier lacks specificity'))
+        Helpers.formatResponseEditionRange(resp)
         // eslint-disable-next-line dot-notation
         resolve(resp.hits.hits[0]['_source'])
       })

--- a/test/esResponseHelpers.test.js
+++ b/test/esResponseHelpers.test.js
@@ -1,0 +1,104 @@
+/* eslint-disable no-undef */
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const Helpers = require('../helpers/esSourceHelpers')
+
+
+chai.should()
+chai.use(sinonChai)
+const { expect } = chai
+
+describe('ElasticSearch Response Parser Helpers', () => {
+  describe('getEditionRangeValue()', () => {
+    let stubGetRange
+    beforeEach(() => {
+      stubGetRange = sinon.stub(Helpers, 'getEditionRangeValue')
+      stubGetRange.onFirstCall().returns('1900')
+      stubGetRange.onSecondCall().returns('2000')
+    })
+
+    afterEach(() => {
+      stubGetRange.restore()
+    })
+
+    it('should return a year from an array of editions', (done) => {
+      const testResp = {
+        took: 0,
+        timed_out: false,
+        hits: {
+          total: 1,
+          max_score: 1,
+          hits: [
+            {
+              _index: 'sfr_test',
+              _type: 'test',
+              _id: 1,
+              _score: 1,
+              _source: {},
+            },
+          ],
+        },
+      }
+      Helpers.formatResponseEditionRange(testResp)
+      // eslint-disable-next-line no-underscore-dangle
+      expect(testResp.hits.hits[0]._source.edition_range).to.equal('1900 - 2000')
+      done()
+    })
+  })
+
+  it('should get a year for a provided set of editions', (done) => {
+    const stubCompare = sinon.stub(Helpers, 'startEndCompare')
+    const testHit = {
+      _source: {
+        instances: [
+          {
+            pub_date: {
+              gte: '2019-01-01',
+              lte: '2020-12-31',
+            },
+          }, {
+            pub_date: null,
+          },
+        ],
+      },
+    }
+
+    const testStart = Helpers.getEditionRangeValue(testHit, 'gte', 1)
+    const testEnd = Helpers.getEditionRangeValue(testHit, 'lte', -1)
+    expect(testStart).to.equal(2019)
+    expect(testEnd).to.equal(2020)
+    stubCompare.restore()
+    done()
+  })
+
+  it('should return ???? if no pub date found', (done) => {
+    const stubCompare = sinon.stub(Helpers, 'startEndCompare')
+    const testHit = {
+      _source: {
+        instances: [
+          {
+            pub_date: null,
+          },
+        ],
+      },
+    }
+
+    const testStart = Helpers.getEditionRangeValue(testHit, 'gte', 1)
+    const testEnd = Helpers.getEditionRangeValue(testHit, 'lte', -1)
+    expect(testStart).to.equal('????')
+    expect(testEnd).to.equal('????')
+    stubCompare.restore()
+    done()
+  })
+
+  it('should generate a comparison function for sorting', (done) => {
+    const compareFunction = Helpers.startEndCompare('gte', 1)
+    expect(compareFunction).to.be.instanceOf(Function)
+    const edition1 = { pub_date: { gte: '1999-01-01', lte: null } }
+    const edition2 = { pub_date: { gte: '2000-01-01', lte: null } }
+    const order = compareFunction(edition1, edition2)
+    expect(order).to.equal(-1)
+    done()
+  })
+})

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -9,6 +9,7 @@ chai.should()
 chai.use(sinonChai)
 const { expect } = chai
 
+const Helpers = require('../helpers/esSourceHelpers')
 const { Search } = require('../lib/search')
 const { MissingParamError } = require('../lib/errors')
 
@@ -55,7 +56,7 @@ describe('v2 simple search tests', () => {
     testSearch.query = {
       build: sinon.stub(),
     }
-    const editionRangeStub = sinon.stub(Search, 'formatResponseEditionRange')
+    const editionRangeStub = sinon.stub(Helpers, 'formatResponseEditionRange')
     const resp = await testSearch.execSearch()
     expect(resp.took).to.equal(0)
     expect(resp.hits.hits.length).to.equal(1)
@@ -101,89 +102,6 @@ describe('v2 simple search tests', () => {
     expect(testBody).to.have.property('aggs')
     expect(testBody.aggs).to.have.property('language')
     expect(testBody.aggs.language).to.have.property('nested')
-    done()
-  })
-
-  it('should return a year from an array of editions', (done) => {
-    const stubGetRange = sinon.stub(Search, 'getEditionRangeValue')
-    stubGetRange.onFirstCall().returns('1900')
-    stubGetRange.onSecondCall().returns('2000')
-    const testResp = {
-      took: 0,
-      timed_out: false,
-      hits: {
-        total: 1,
-        max_score: 1,
-        hits: [
-          {
-            _index: 'sfr_test',
-            _type: 'test',
-            _id: 1,
-            _score: 1,
-            _source: {},
-          },
-        ],
-      },
-    }
-    Search.formatResponseEditionRange(testResp)
-    // eslint-disable-next-line no-underscore-dangle
-    expect(testResp.hits.hits[0]._source.edition_range).to.equal('1900 - 2000')
-    stubGetRange.restore()
-    done()
-  })
-
-  it('should get a year for a provided set of editions', (done) => {
-    const stubCompare = sinon.stub(Search, 'startEndCompare')
-    const testHit = {
-      _source: {
-        instances: [
-          {
-            pub_date: {
-              gte: '2019-01-01',
-              lte: '2020-12-31',
-            },
-          }, {
-            pub_date: null,
-          },
-        ],
-      },
-    }
-
-    const testStart = Search.getEditionRangeValue(testHit, 'gte', 1)
-    const testEnd = Search.getEditionRangeValue(testHit, 'lte', -1)
-    expect(testStart).to.equal(2019)
-    expect(testEnd).to.equal(2020)
-    stubCompare.restore()
-    done()
-  })
-
-  it('should return ???? if no pub date found', (done) => {
-    const stubCompare = sinon.stub(Search, 'startEndCompare')
-    const testHit = {
-      _source: {
-        instances: [
-          {
-            pub_date: null,
-          },
-        ],
-      },
-    }
-
-    const testStart = Search.getEditionRangeValue(testHit, 'gte', 1)
-    const testEnd = Search.getEditionRangeValue(testHit, 'lte', -1)
-    expect(testStart).to.equal('????')
-    expect(testEnd).to.equal('????')
-    stubCompare.restore()
-    done()
-  })
-
-  it('should generate a comparison function for sorting', (done) => {
-    const compareFunction = Search.startEndCompare('gte', 1)
-    expect(compareFunction).to.be.instanceOf(Function)
-    const edition1 = { pub_date: { gte: '1999-01-01', lte: null } }
-    const edition2 = { pub_date: { gte: '2000-01-01', lte: null } }
-    const order = compareFunction(edition1, edition2)
-    expect(order).to.equal(-1)
     done()
   })
 

--- a/test/v2Work.test.js
+++ b/test/v2Work.test.js
@@ -9,6 +9,7 @@ chai.use(sinonChai)
 chai.use(chaiPromise)
 const { expect } = chai
 
+const Helpers = require('../helpers/esSourceHelpers')
 const { fetchWork } = require('../routes/v2/work')
 const { ElasticSearchError, MissingParamError } = require('../lib/errors')
 
@@ -23,6 +24,7 @@ describe('v2 single work retrieval tests', () => {
 
   it('should return a single record for a successful query', async () => {
     const testClient = sinon.stub()
+    const testRange = sinon.stub(Helpers, 'formatResponseEditionRange')
     testClient.resolves({
       took: 0,
       timed_out: false,
@@ -54,6 +56,7 @@ describe('v2 single work retrieval tests', () => {
     const resp = await fetchWork(params, testApp)
     expect(resp.uuid).to.equal(1)
     expect(resp.title).to.equal('Test Work')
+    testRange.restore()
   })
 
   it('should raise error if multiple records received', async () => {


### PR DESCRIPTION
This refactors the code that calculates the full range of edition years into a separate helper module so that it can be accessed by the individual `Work` endpoint as well as the Search endpoint. Also refactored is the test suite to reflect this new division of responsibilities.