### PR TITLE
Replace title.keyword with sort_title for sorting

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -301,7 +301,7 @@ class Search {
         const { field, dir } = sort
         switch (field) {
           case 'title':
-            sorts.push({ 'title.keyword': dir || 'ASC' })
+            sorts.push({ sort_title: dir || 'ASC' })
             break
           default:
             sorts.push({ [field]: dir || 'ASC' })

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -134,7 +134,7 @@ describe('v2 simple search tests', () => {
     done()
   })
 
-  it('should a title.keyword sort for a title sort option', (done) => {
+  it('should sort on sort_title for a title sort option', (done) => {
     const testApp = sinon.mock()
     const testParams = { sort: [{ field: 'title' }] }
     const testSearch = new Search(testApp, testParams)
@@ -142,8 +142,8 @@ describe('v2 simple search tests', () => {
     testSearch.addSort()
     testBody = testSearch.query.build()
     expect(testBody).to.have.property('sort')
-    expect(testBody.sort[0]).to.have.property('title.keyword')
-    expect(testBody.sort[0]['title.keyword'].order).to.equal('ASC')
+    expect(testBody.sort[0]).to.have.property('sort_title')
+    expect(testBody.sort[0].sort_title.order).to.equal('ASC')
     expect(testBody.sort[1]).to.have.property('uuid')
     done()
   })


### PR DESCRIPTION
Within the API, the script was erronously using the title keyword field (keyword fields are not tokenized and are therefore faster for sorting), instead of the sort_title field, which is also keyword based.

Also updates the test case covering title sorting