### PR TITLE
Fix oversize JSON response

### DIFF
--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -9,8 +9,15 @@ const formatResponseEditionRange = (resp) => {
     const startYear = module.exports.getEditionRangeValue(hit, 'gte', 1)
     const endYear = module.exports.getEditionRangeValue(hit, 'lte', -1)
 
+    let editionRange = ''
+    if (startYear !== endYear) {
+      editionRange = `${startYear} - ${endYear}`
+    } else {
+      editionRange = startYear
+    }
+
     // eslint-disable-next-line no-param-reassign, no-underscore-dangle
-    hit._source.edition_range = `${startYear} - ${endYear}`
+    hit._source.edition_range = editionRange
   })
 }
 
@@ -27,7 +34,8 @@ const formatResponseEditionRange = (resp) => {
  */
 const getEditionRangeValue = (hit, range, flip) => {
   let year
-  // eslint-disable-next-line no-underscore-dangle
+  /* eslint-disable no-underscore-dangle */
+  if (!hit._source.instances) { return '????' }
   const rangeInstance = hit._source.instances.sort(
     module.exports.startEndCompare(range, flip),
   ).filter(instance => instance.pub_date)[0]
@@ -39,6 +47,7 @@ const getEditionRangeValue = (hit, range, flip) => {
   // eslint-disable-next-line no-restricted-globals
   if (isNaN(year)) { year = '????' }
   return year
+  /* eslint-enable no-underscore-dangle */
 }
 
 /**

--- a/lib/search.js
+++ b/lib/search.js
@@ -64,8 +64,8 @@ class Search {
   static filterSearchEditions(resp) {
     resp.hits.hits.forEach((hit) => {
       /* eslint-disable no-param-reassign, no-underscore-dangle */
-      hit._source.edition_count = hit._source.instances.length
-      hit._source.instances = hit._source.instances.slice(0, 3)
+      hit._source.edition_count = hit._source.instances ? hit._source.instances.length : 0
+      hit._source.instances = hit._source.instances ? hit._source.instances.slice(0, 3) : []
       /* eslint-enable no-param-reassign, no-underscore-dangle */
     })
   }

--- a/lib/search.js
+++ b/lib/search.js
@@ -48,9 +48,23 @@ class Search {
           Search.formatResponsePaging(resp)
           Search.formatResponseFacets(resp)
           Helpers.formatResponseEditionRange(resp)
+          Search.filterSearchEditions(resp)
           resolve(resp)
         })
         .catch(error => reject(error))
+    })
+  }
+
+  /**
+   * Removes all but the top three most relevant instances/editions for each
+   * returned work record.
+   *
+   * @param {Object} resp ElasticSearch search response object
+   */
+  static filterSearchEditions(resp) {
+    resp.hits.hits.forEach((hit) => {
+      // eslint-disable-next-line no-param-reassign, no-underscore-dangle
+      hit._source.instances = hit._source.instances.slice(0, 3)
     })
   }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -63,8 +63,10 @@ class Search {
    */
   static filterSearchEditions(resp) {
     resp.hits.hits.forEach((hit) => {
-      // eslint-disable-next-line no-param-reassign, no-underscore-dangle
+      /* eslint-disable no-param-reassign, no-underscore-dangle */
+      hit._source.edition_count = hit._source.instances.length
       hit._source.instances = hit._source.instances.slice(0, 3)
+      /* eslint-enable no-param-reassign, no-underscore-dangle */
     })
   }
 

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -206,6 +206,7 @@ describe('v2 simple search tests', () => {
     /* eslint-disable no-underscore-dangle */
     expect(testResp.hits.hits[0]._source.instances.length).to.equal(3)
     expect(testResp.hits.hits[0]._source.instances[2].id).to.equal(3)
+    expect(testResp.hits.hits[0]._source.edition_count).to.equal(4)
     /* eslint-enable no-underscore-dangle */
     done()
   })

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -56,11 +56,13 @@ describe('v2 simple search tests', () => {
     testSearch.query = {
       build: sinon.stub(),
     }
+    const instanceFilter = sinon.stub(Search, 'filterSearchEditions')
     const editionRangeStub = sinon.stub(Helpers, 'formatResponseEditionRange')
     const resp = await testSearch.execSearch()
     expect(resp.took).to.equal(0)
     expect(resp.hits.hits.length).to.equal(1)
     editionRangeStub.restore()
+    instanceFilter.restore()
   })
 
   it('should create facet object for response', (done) => {
@@ -171,6 +173,40 @@ describe('v2 simple search tests', () => {
     expect(testBody).to.have.property('sort')
     expect(testBody.sort[0]).to.have.property('_score')
     expect(testBody.sort[1]).to.have.property('uuid')
+    done()
+  })
+
+  it('should slice instance array down to first 3 instances', (done) => {
+    const testResp = {
+      took: 0,
+      timed_out: false,
+      hits: {
+        total: 1,
+        max_score: 1,
+        hits: [
+          {
+            _index: 'sfr_test',
+            _type: 'test',
+            _id: 1,
+            _score: 1,
+            _source: {
+              instances: [
+                { id: 1 },
+                { id: 2 },
+                { id: 3 },
+                { id: 4 },
+              ],
+            },
+          },
+        ],
+      },
+      aggregations: {},
+    }
+    Search.filterSearchEditions(testResp)
+    /* eslint-disable no-underscore-dangle */
+    expect(testResp.hits.hits[0]._source.instances.length).to.equal(3)
+    expect(testResp.hits.hits[0]._source.instances[2].id).to.equal(3)
+    /* eslint-enable no-underscore-dangle */
     done()
   })
 })


### PR DESCRIPTION
Currently the search API returns a full set of editions for the search result response. This is unecessary as only the top three will ever be displayed. Too large responses both affect performance and can cause axios to throw a 500 error when handling a response of over 5MB (roughly).

This also implements a stub function that will be able to sort/filter editions depending on the current search criteria, which is a task that is currently in the backlog. This implements no functionality, but provides a method and testing framework that can be built into this.