### PR TITLE
SFR 79 add author sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ The paging options are:
 
 Basic sorting is implemented to support the requirements of the next/previous page functionality. The default sort is by the internal ElasticSearch scoring algorithm, based off the initial search query. This can be changed to any field in the index. Adding a sort involves placing a single parameter, `sort`, in the request, which is an array of objects with the following fields:
 
-- `field` The field to sort the results on
+- `field` The field to sort the results on. The currently valid sorting options are:
+  - title
+  - author
 - `dir` The direction of the sort, either `asc` or `desc`
 
 ## Filtering

--- a/lib/search.js
+++ b/lib/search.js
@@ -319,6 +319,17 @@ class Search {
           case 'title':
             sorts.push({ sort_title: dir || 'ASC' })
             break
+          case 'author':
+            sorts.push({
+              'agents.sort_name': {
+                order: dir || 'ASC',
+                nested: {
+                  path: 'agents',
+                  filter: { bool: { must_not: { terms: { 'agents.roles': blacklistRoles } } } },
+                },
+              },
+            })
+            break
           default:
             sorts.push({ [field]: dir || 'ASC' })
         }

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -668,7 +668,7 @@
           "type": "string",
           "example": "title",
           "description": "An ElasticSearch field to sort results by",
-          "enum": ["title"]
+          "enum": ["title", "author"]
         },
         "dir": {
           "type": "string",

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -150,6 +150,20 @@ describe('v2 simple search tests', () => {
     done()
   })
 
+  it('should sort on agents.sort_name for an author sort', (done) => {
+    const testApp = sinon.mock()
+    const testParams = { sort: [{ field: 'author', dir: 'DESC' }] }
+    const testSearch = new Search(testApp, testParams)
+    testSearch.query = bodybuilder()
+    testSearch.addSort()
+    testBody = testSearch.query.build()
+    expect(testBody).to.have.property('sort')
+    expect(testBody.sort[0]).to.have.property('agents.sort_name')
+    expect(testBody.sort[0]['agents.sort_name'].order).to.equal('DESC')
+    expect(testBody.sort[1]).to.have.property('uuid')
+    done()
+  })
+
   it('should add a field sort for an arbitrary sort option', (done) => {
     const testApp = sinon.mock()
     const testParams = { sort: [{ field: 'testing', dir: 'DESC' }] }


### PR DESCRIPTION
Implement the author sorting option. This uses the nested `agent` records within each `work` record to provide the sorting functionality. The agent records are filtered for sorting purposes with the same blacklist that is applied when searching for authors.

This uses the "primary" author if available and if not, the first author that appears in the list.