### PR TITLE
SFR-80 Add date sort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Basic sorting is implemented to support the requirements of the next/previous pa
 - `field` The field to sort the results on. The currently valid sorting options are:
   - title
   - author
+  - date (This sorts on either the first or last publication date, depending on the sort direction)
 - `dir` The direction of the sort, either `asc` or `desc`
 
 ## Filtering

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const config = require('config')
 const express = require('express')
 const bodyParser = require('body-parser')
 const SwaggerParser = require('swagger-parser')
+const swaggerUI = require('swagger-ui-express')
 const logger = require('./lib/logger')
 const swaggerDocs = require('./swagger.v2.json')
 
@@ -34,9 +35,7 @@ app.use('/v1', v1Router)
 app.use('/', v1Router) // Controls default version of app
 
 // TODO: Implement different Swagger doc versions for versions of the API
-app.get('/research-now/swagger', (req, res) => {
-  res.send(swaggerDocs)
-})
+app.use('/research-now/swagger', swaggerUI.serve, swaggerUI.setup(swaggerDocs))
 
 app.get('/research-now/swagger-test', (req, res) => {
   SwaggerParser.validate(swaggerDocs, (err, api) => {

--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -40,7 +40,7 @@ const getEditionRangeValue = (hit, range, flip) => {
     module.exports.startEndCompare(range, flip),
   ).filter(instance => instance.pub_date)[0]
   if (rangeInstance) {
-    year = new Date(`${rangeInstance.pub_date[range]}T12:00:00.000+00:00`).getFullYear()
+    year = new Date(`${rangeInstance.pub_date[range]}Z`).getUTCFullYear()
   } else {
     year = '????'
   }
@@ -81,8 +81,8 @@ const startEndCompare = (startEnd, sortFlip) => {
     if (!a.pub_date[startEnd]) return -1 * sortFlip
     if (!b.pub_date[startEnd]) return 1 * sortFlip
 
-    const d1 = new Date(`${a.pub_date[startEnd]}T12:00:00.000+00:00`).getFullYear()
-    const d2 = new Date(`${b.pub_date[startEnd]}T12:00:00.000+00:00`).getFullYear()
+    const d1 = new Date(`${a.pub_date[startEnd]}Z`).getUTCFullYear()
+    const d2 = new Date(`${b.pub_date[startEnd]}Z`).getUTCFullYear()
 
     if (d1 > d2) return 1 * sortFlip
     if (d1 < d2) return -1 * sortFlip

--- a/lib/search.js
+++ b/lib/search.js
@@ -330,6 +330,18 @@ class Search {
               },
             })
             break
+          case 'date':
+            // eslint-disable-next-line no-case-declarations
+            const sortField = dir === 'DESC' ? 'instances.pub_date_sort_desc' : 'instances.pub_date_sort'
+            sorts.push({
+              [sortField]: {
+                order: dir || 'ASC',
+                nested: {
+                  path: 'instances',
+                },
+              },
+            })
+            break
           default:
             sorts.push({ [field]: dir || 'ASC' })
         }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "request": "2.88.0",
     "swagger-client": "^3.8.22",
     "swagger-parser": "^6.0.2",
+    "swagger-ui-express": "^4.0.6",
     "winston": "3.1.0"
   },
   "devDependencies": {

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -578,7 +578,8 @@
         "field": {
           "description": "Field to query. Currently supports: Keyword, Title, Author and Subject. Defaults to Keyword",
           "type": "string",
-          "example": "keyword|title|author|subject"
+          "example": "keyword",
+          "enum": ["keyword", "title", "author", "subject"]
         },
         "query": {
           "description": "Query term to search. This is a free-text field and which understands standard boolean search terms as well as quoted strings for exact matching.",
@@ -668,7 +669,7 @@
           "type": "string",
           "example": "title",
           "description": "An ElasticSearch field to sort results by",
-          "enum": ["title", "author"]
+          "enum": ["title", "author", "date"]
         },
         "dir": {
           "type": "string",
@@ -684,17 +685,24 @@
       "properties": {
         "field": {
           "type": "string",
-          "example": "language",
           "enum": ["language", "years"],
           "description": "Field on which to match results by (effectively exact-match search)"
         },
         "value": {
           "type": "object",
           "$ref": "#/definitions/FilterObject",
-          "example": "English",
           "description": "Value on which to filter. Can be a string (for term filters), or an object such as {start: 1900, end: 2000} for years"
         }
-      }
+      },
+      "example": [
+        {
+          "field": "language",
+          "value": "Spanish"
+        },{
+          "field": "years",
+          "value": {"start": 1800, "end": 2000}
+        }
+    ]
     },
     "QueryBlock": {
       "title": "Query",

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -164,6 +164,34 @@ describe('v2 simple search tests', () => {
     done()
   })
 
+  it('should sort on instances.pub_date_sort for ASC date sort', (done) => {
+    const testApp = sinon.mock()
+    const testParams = { sort: [{ field: 'date' }] }
+    const testSearch = new Search(testApp, testParams)
+    testSearch.query = bodybuilder()
+    testSearch.addSort()
+    testBody = testSearch.query.build()
+    expect(testBody).to.have.property('sort')
+    expect(testBody.sort[0]).to.have.property('instances.pub_date_sort')
+    expect(testBody.sort[0]['instances.pub_date_sort'].order).to.equal('ASC')
+    expect(testBody.sort[1]).to.have.property('uuid')
+    done()
+  })
+
+  it('should sort on instances.pub_date_sort_desc for DESC date sort', (done) => {
+    const testApp = sinon.mock()
+    const testParams = { sort: [{ field: 'date', dir: 'DESC' }] }
+    const testSearch = new Search(testApp, testParams)
+    testSearch.query = bodybuilder()
+    testSearch.addSort()
+    testBody = testSearch.query.build()
+    expect(testBody).to.have.property('sort')
+    expect(testBody.sort[0]).to.have.property('instances.pub_date_sort_desc')
+    expect(testBody.sort[0]['instances.pub_date_sort_desc'].order).to.equal('DESC')
+    expect(testBody.sort[1]).to.have.property('uuid')
+    done()
+  })
+
   it('should add a field sort for an arbitrary sort option', (done) => {
     const testApp = sinon.mock()
     const testParams = { sort: [{ field: 'testing', dir: 'DESC' }] }


### PR DESCRIPTION
This adds `date` as a sort option based on the publication dates associated with instance records.

To support this feature two new fields were added to the instance records `pub_date_sort` and `pub_date_sort_desc`, which support sorting on the date field in both directions. This was necessary as the existing `pub_date` field is a `DateRange` field that cannot be sorted on, but which is retained as it provides an easy means of searching/filtering on this data (the range aspect especially is used in the `filter` functionality)

In addition to the usual tests and documentation this adds some additional support around the swagger documentation, specifically a new piece of middleware to allow the swagger docs to be viewed locally. This allows changes to this documentation to be viewed in the UI before deployment, enabling changes to be made more confidently and cutting down on follow up changes if the documentation does not reflect the intended changes.