### PR TITLE
SFR-515 Add Edition Filtering

### DIFF
--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -36,7 +36,8 @@ const getEditionRangeValue = (hit, range, flip) => {
   let year
   /* eslint-disable no-underscore-dangle */
   if (!hit._source.instances) { return '????' }
-  const rangeInstance = hit._source.instances.sort(
+  const instanceSorter = hit._source.instances.map(o => ({ ...o }))
+  const rangeInstance = instanceSorter.sort(
     module.exports.startEndCompare(range, flip),
   ).filter(instance => instance.pub_date)[0]
   if (rangeInstance) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -406,7 +406,9 @@ class Search {
   addFilters() {
     if ('filters' in this.params && this.params.filters instanceof Array) {
       // eslint-disable-next-line array-callback-return
-      this.params.filters.map((filter) => {
+      let yearFilter = null
+      const langFilters = []
+      this.params.filters.forEach((filter) => {
         const { field, value } = filter
         switch (field) {
           case 'years':
@@ -416,19 +418,29 @@ class Search {
             if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
             if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
             dateRange.relation = 'WITHIN'
-            this.query.query('nested', { path: 'instances', query: { range: { 'instances.pub_date': dateRange } }, inner_hits: { _source: false } })
+            yearFilter = ['range', 'instances.pub_date', dateRange]
             break
           case 'language':
             this.logger.debug(`Filtering works by language ${value}`)
-            this.query.query('bool', a => a
-              .orQuery('nested', { path: 'language', query: { term: { 'language.language': value } } })
-              .orQuery('nested', { path: 'instances.language', query: { term: { 'instances.language.language': value } }, inner_hits: { _source: false } }))
+            langFilters.push(['nested', { path: 'instances.language', query: { term: { 'instances.language.language': value } } }])
             break
           default:
             this.logger.warning('API Not configured to handle this filter')
             break
         }
       })
+      if (yearFilter || langFilters.length > 0) {
+        this.query.query('nested', { path: 'instances', inner_hits: { size: 100 } }, (q) => {
+          if (yearFilter) { q.query(...yearFilter) }
+          if (langFilters.length > 0) {
+            q.query('bool', (a) => {
+              langFilters.forEach(lang => a.orQuery(...lang))
+              return a
+            })
+          }
+          return q
+        })
+      }
     }
   }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -356,6 +356,7 @@ class Search {
             const dateRange = {}
             if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
             if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
+            dateRange.relation = 'WITHIN'
             this.query.query('nested', { path: 'instances', query: { range: { 'instances.pub_date': dateRange } } })
             break
           case 'language':

--- a/lib/search.js
+++ b/lib/search.js
@@ -382,9 +382,9 @@ class Search {
   addAggregations() {
     // Add aggregation for language facet
     const langFacet = 'language'
-    this.query.agg('nested', { path: 'language' }, langFacet, a => a.agg('terms', 'language.language'))
+    this.query.agg('nested', { path: 'language' }, langFacet, a => a.agg('terms', 'language.language', { size: 200 }))
 
-    this.query.agg('nested', { path: 'instances.language' }, langFacet, a => a.agg('terms', 'instances.language.language', langFacet, b => b.agg('reverse_nested', {}, langFacet)))
+    this.query.agg('nested', { path: 'instances.language' }, langFacet, a => a.agg('terms', 'instances.language.language', { size: 200 }, langFacet, b => b.agg('reverse_nested', {}, langFacet)))
   }
 }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -83,16 +83,27 @@ class Search {
           }
         })
         instancePos.forEach((pos) => {
-          console.log('ADDING EDITION', pos)
           topInstances.push(hit._source.instances[pos])
         })
+        topInstances = Search.removeInvalidEditions(topInstances).slice(0, 3)
       } else {
-        topInstances = hit._source.instances ? hit._source.instances.slice(0, 3) : []
+        topInstances = hit._source.instances
+          ? Search.removeInvalidEditions(hit._source.instances).slice(0, 3) : []
       }
-      hit._source.edition_count = hit._source.instances ? hit._source.instances.length : 0
+      hit._source.edition_count = hit._source.instances
+        ? Search.removeInvalidEditions(hit._source.instances).length : 0
       hit._source.instances = topInstances
       /* eslint-enable no-param-reassign, no-underscore-dangle */
     })
+  }
+
+  static removeInvalidEditions(editionList) {
+    return editionList.filter(ed => (
+      (ed.items && ed.items.length > 0)
+        || ed.pub_date
+        || (ed.agents && ed.agents.length > 0)
+        || ed.pub_place
+    ))
   }
 
   /**

--- a/lib/search.js
+++ b/lib/search.js
@@ -64,8 +64,33 @@ class Search {
   static filterSearchEditions(resp) {
     resp.hits.hits.forEach((hit) => {
       /* eslint-disable no-param-reassign, no-underscore-dangle */
+      let topInstances = []
+      if (hit.inner_hits) {
+        const innerSets = []
+        Object.values(hit.inner_hits).forEach((match) => {
+          const matchOffsets = new Set()
+          match.hits.hits.forEach((inner) => {
+            matchOffsets.add(inner._nested.offset)
+          })
+          innerSets.push(matchOffsets)
+        })
+        let instancePos = new Set()
+        innerSets.forEach((set) => {
+          if ([...instancePos].length === 0) {
+            set.forEach(offset => instancePos.add(offset))
+          } else {
+            instancePos = new Set([...set].filter(x => instancePos.has(x)))
+          }
+        })
+        instancePos.forEach((pos) => {
+          console.log('ADDING EDITION', pos)
+          topInstances.push(hit._source.instances[pos])
+        })
+      } else {
+        topInstances = hit._source.instances ? hit._source.instances.slice(0, 3) : []
+      }
       hit._source.edition_count = hit._source.instances ? hit._source.instances.length : 0
-      hit._source.instances = hit._source.instances ? hit._source.instances.slice(0, 3) : []
+      hit._source.instances = topInstances
       /* eslint-enable no-param-reassign, no-underscore-dangle */
     })
   }
@@ -379,13 +404,13 @@ class Search {
             const dateRange = {}
             if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
             if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
-            this.query.query('nested', { path: 'instances', query: { range: { 'instances.pub_date': dateRange } } })
+            this.query.query('nested', { path: 'instances', query: { range: { 'instances.pub_date': dateRange } }, inner_hits: { _source: false } })
             break
           case 'language':
             this.logger.debug(`Filtering works by language ${value}`)
             this.query.query('bool', a => a
               .orQuery('nested', { path: 'language', query: { term: { 'language.language': value } } })
-              .orQuery('nested', { path: 'instances.language', query: { term: { 'instances.language.language': value } } }))
+              .orQuery('nested', { path: 'instances.language', query: { term: { 'instances.language.language': value } }, inner_hits: { _source: false } }))
             break
           default:
             this.logger.warning('API Not configured to handle this filter')

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -107,33 +107,49 @@ describe('v2 simple search tests', () => {
     done()
   })
 
-  it('should add gte/lte date filter on publication dates', (done) => {
-    const testApp = sinon.mock()
-    testApp.logger = logger
-    const testParams = { filters: [{ field: 'years', value: { start: 1900, end: 2000 } }] }
-    const testSearch = new Search(testApp, testParams)
-    testSearch.query = bodybuilder()
-    testSearch.addFilters()
-    testBody = testSearch.query.build()
-    expect(testBody).to.have.property('query')
-    expect(testBody.query.nested.query.range['instances.pub_date'].gte.getTime()).to.equal(new Date('1900-01-01T12:00:00.000+00:00').getTime())
-    expect(testBody.query.nested.query.range['instances.pub_date'].lte.getTime()).to.equal(new Date('2000-12-31T12:00:00.000+00:00').getTime())
-    done()
-  })
+  describe('addFilters()', () => {
+    it('should add gte/lte date filter on publication dates', (done) => {
+      const testApp = sinon.mock()
+      testApp.logger = logger
+      const testParams = { filters: [{ field: 'years', value: { start: 1900, end: 2000 } }] }
+      const testSearch = new Search(testApp, testParams)
+      testSearch.query = bodybuilder()
+      testSearch.addFilters()
+      testBody = testSearch.query.build()
+      expect(testBody).to.have.property('query')
+      expect(testBody.query.nested.query.range['instances.pub_date'].gte.getTime()).to.equal(new Date('1900-01-01T12:00:00.000+00:00').getTime())
+      expect(testBody.query.nested.query.range['instances.pub_date'].lte.getTime()).to.equal(new Date('2000-12-31T12:00:00.000+00:00').getTime())
+      done()
+    })
 
-  it('should add gte date filter on publication dates if only start is provided', (done) => {
-    const testApp = sinon.mock()
-    testApp.logger = logger
-    const testParams = { filters: [{ field: 'years', value: { start: 1900 } }] }
-    const testSearch = new Search(testApp, testParams)
-    testSearch.query = bodybuilder()
-    testSearch.addFilters()
-    testBody = testSearch.query.build()
-    expect(testBody).to.have.property('query')
-    expect(testBody.query.nested.query.range['instances.pub_date'].gte.getTime()).to.equal(new Date('1900-01-01T12:00:00.000+00:00').getTime())
-    // eslint-disable-next-line no-unused-expressions
-    expect(testBody.query.nested.query.range['instances.pub_date'].lte).to.be.undefined
-    done()
+    it('should add gte date filter on publication dates if only start is provided', (done) => {
+      const testApp = sinon.mock()
+      testApp.logger = logger
+      const testParams = { filters: [{ field: 'years', value: { start: 1900 } }] }
+      const testSearch = new Search(testApp, testParams)
+      testSearch.query = bodybuilder()
+      testSearch.addFilters()
+      testBody = testSearch.query.build()
+      expect(testBody).to.have.property('query')
+      expect(testBody.query.nested.query.range['instances.pub_date'].gte.getTime()).to.equal(new Date('1900-01-01T12:00:00.000+00:00').getTime())
+      // eslint-disable-next-line no-unused-expressions
+      expect(testBody.query.nested.query.range['instances.pub_date'].lte).to.be.undefined
+      done()
+    })
+
+    it('should add multiple language filters in a bool query block', (done) => {
+      const testApp = sinon.mock()
+      testApp.logger = logger
+      const testParams = { filters: [{ field: 'language', value: 'Testing' }, { field: 'language', value: 'Hello' }] }
+      const testSearch = new Search(testApp, testParams)
+      testSearch.query = bodybuilder()
+      testSearch.addFilters()
+      testBody = testSearch.query.build()
+      expect(testBody).to.have.property('query')
+      expect(testBody.query.nested.query.bool.should[0].nested.query.term['instances.language.language']).to.equal('Testing')
+      expect(testBody.query.nested.query.bool.should[1].nested.query.term['instances.language.language']).to.equal('Hello')
+      done()
+    })
   })
 
   it('should sort on sort_title for a title sort option', (done) => {
@@ -219,6 +235,7 @@ describe('v2 simple search tests', () => {
   })
 
   it('should slice instance array down to first 3 instances', (done) => {
+    const invalidStub = sinon.stub(Search, 'removeInvalidEditions')
     const testResp = {
       took: 0,
       timed_out: false,
@@ -244,12 +261,85 @@ describe('v2 simple search tests', () => {
       },
       aggregations: {},
     }
-    Search.filterSearchEditions(testResp)
     /* eslint-disable no-underscore-dangle */
+    invalidStub.returns(testResp.hits.hits[0]._source.instances)
+    Search.filterSearchEditions(testResp)
     expect(testResp.hits.hits[0]._source.instances.length).to.equal(3)
     expect(testResp.hits.hits[0]._source.instances[2].id).to.equal(3)
     expect(testResp.hits.hits[0]._source.edition_count).to.equal(4)
     /* eslint-enable no-underscore-dangle */
+    invalidStub.restore()
+    done()
+  })
+
+  it('filter on inner_hits, then slice top three', (done) => {
+    const invalidStub = sinon.stub(Search, 'removeInvalidEditions')
+    const testResp = {
+      took: 0,
+      timed_out: false,
+      hits: {
+        total: 1,
+        max_score: 1,
+        hits: [
+          {
+            _index: 'sfr_test',
+            _type: 'test',
+            _id: 1,
+            _score: 1,
+            _source: {
+              instances: [
+                { id: 1 },
+                { id: 2 },
+                { id: 3 },
+                { id: 4 },
+              ],
+            },
+            inner_hits: {
+              testing: {
+                hits: {
+                  hits: [
+                    { _nested: { offset: 1 } },
+                    { _nested: { offset: 3 } },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+      aggregations: {},
+    }
+    /* eslint-disable no-underscore-dangle */
+    invalidStub.returns([{ id: 2 }, { id: 4 }])
+    Search.filterSearchEditions(testResp)
+    expect(testResp.hits.hits[0]._source.instances.length).to.equal(2)
+    expect(testResp.hits.hits[0]._source.instances[1].id).to.equal(4)
+    expect(testResp.hits.hits[0]._source.edition_count).to.equal(2)
+    /* eslint-enable no-underscore-dangle */
+    invalidStub.restore()
+    done()
+  })
+
+  it('should remove editions lacking metadata', (done) => {
+    const testEditions = [
+      {
+        title: 'Testing',
+      }, {
+        title: 'Testing 2',
+        pub_date: '2019',
+      }, {
+        title: 'Testing 3',
+        items: [
+          {
+            media_type: 'application/pdf',
+            links: [],
+          },
+        ],
+      },
+    ]
+    filteredEditions = Search.removeInvalidEditions(testEditions)
+    expect(filteredEditions.length).to.equal(2)
+    expect(filteredEditions[0].pub_date).to.equal('2019')
     done()
   })
 })


### PR DESCRIPTION
This applies the currently set filters to the edition records within each work, surfacing the most relevant editions for the current search/filter criteria in the search results.

This utilizes the `inner_hits` functionality of ElasticSearch to apply these criteria to the documents within each work record.

There are numerous supporting changes around the addition of this core functionality:

- The `edition_count` and `edition_range` features are calculated from a deep copy of the edition array to ensure that they are calculated from the full set and not the filtered set of editions
- The `language` and `years` filters are now calculated dynamically within a single `nested` query to ensure that they are applied together on editions, returning only editions that meet _all_ the relevant filters, not just _any_ of them
- Editions containing no relevant metadata are filtered from the response to ensure that only relevant editions are surfaced (and to align the API functionality with the front-end app)
- Improved matching for language and date filters, ensuring more accurate edition results
  - Altering the `DateRange` filtering to match `WITHIN` the specified range
  - Extending the number of `language` facets returned to ensure that accurate counts are always reflected in the front-end application