### PR TITLE
SFR-79 Update author sort to match front-end behavior

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -361,7 +361,8 @@ class Search {
                 order: dir || 'ASC',
                 nested: {
                   path: 'agents',
-                  filter: { bool: { must_not: { terms: { 'agents.roles': blacklistRoles } } } },
+                  filter: { terms: { 'agents.roles': ['author'] } },
+                  max_children: 1,
                 },
               },
             })


### PR DESCRIPTION
This coerces the `author` sort option to use authors and ensure that it selects only the first author for a work when a primary author is not present