### PR TITLE
SFR-525 Block empty date filters

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -413,13 +413,15 @@ class Search {
         const { field, value } = filter
         switch (field) {
           case 'years':
-            this.logger.debug(`Filtering works by years ${value.start} to ${value.end}`)
-            // eslint-disable-next-line no-case-declarations
-            const dateRange = {}
-            if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
-            if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
-            dateRange.relation = 'WITHIN'
-            yearFilter = ['range', 'instances.pub_date', dateRange]
+            if (value.start !== '' || value.end !== '') {
+              this.logger.debug(`Filtering works by years ${value.start} to ${value.end}`)
+              // eslint-disable-next-line no-case-declarations
+              const dateRange = {}
+              if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
+              if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
+              dateRange.relation = 'WITHIN'
+              yearFilter = ['range', 'instances.pub_date', dateRange]
+            }
             break
           case 'language':
             this.logger.debug(`Filtering works by language ${value}`)


### PR DESCRIPTION
It is possible to receive an "empty" date filter as part of a search request from the front-end app (with empty strings for the `start` and `end` years), which inadvertently filters the results for only those with valid publication dates. This may not be desirable and when "clearing" filters can result in discrepancies in the total number of results returned.

This adds a simple check to be sure that the filter contains at least one valid year, indicating that this is a legitimate filter request