### PR TITLE
SFR-543 Add show_all filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Filtering is supported on a set of pre-defined fields. At present the following 
 
 - `language`: Filters results to return only works matching the provided language
 - `years`: Filters results to return only works with publication dates based off the provided range. This is calculated from the publication dates associated with the editions for each work. This should be formatted as `{"start": year, "end": year}`.
+- `show_all`: By default, the search results only include works with editions that have readable copies (either downloadable or available to read online). Setting this value to `true` will return all works, regardless of this status, in the search results.
 
 ## Aggregations/Facets
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -28,6 +28,8 @@ class Search {
     this.app = app
     this.params = params
     this.logger = this.app.logger
+
+    this.show_all_works = false
   }
 
   /**
@@ -140,17 +142,37 @@ class Search {
     const facets = {}
     Object.keys(resp.aggregations).forEach((agg) => {
       const items = []
-      const curAgg = resp.aggregations[agg]
-      curAgg[agg].buckets.forEach((bucket) => {
-        items.push({ value: bucket.key, count: bucket[agg].doc_count })
+      const aggRoot = agg.slice(0, -2)
+      const { buckets, lastLevel } = Search.getAggBottom(resp.aggregations[agg], aggRoot, 2)
+      buckets.forEach((bucket) => {
+        items.push({ value: bucket.key, count: bucket[lastLevel].doc_count })
       })
       items.sort((a, b) => b.count - a.count)
-      facets[agg] = items
+      facets[aggRoot] = items
     })
     /* eslint-disable no-param-reassign */
     resp.facets = facets
     delete resp.aggregations
     /* eslint-enable no-param-reassign */
+  }
+
+  /**
+   * Recursively descend through an aggregation object to get the final set of
+   * buckets that was the target of the original aggregation.
+   *
+   * @param {Object} agg Root aggregation object returned by ElasticSearch
+   * @param {String} root Root name for the current aggregation
+   * @param {Integer} pos Current position in the aggregation (levels from top)
+   */
+  static getAggBottom(agg, root, pos) {
+    const aggKeys = Object.keys(agg)
+    const aggLevel = `${root}_${pos}`
+    if (aggKeys.indexOf(aggLevel) > -1) {
+      const newPos = pos + 1
+      return Search.getAggBottom(agg[aggLevel], root, newPos)
+    }
+
+    return { buckets: agg.buckets, lastLevel: aggLevel }
   }
 
   /**
@@ -405,10 +427,11 @@ class Search {
    * be custom defined here to ensure proper discovery and refinement.
    */
   addFilters() {
+    let yearFilter = null
+    let readFilter = ['nested', { path: 'instances.items', query: { exists: { field: 'instances.items.source' } } }]
+    const langFilters = []
     if ('filters' in this.params && this.params.filters instanceof Array) {
       // eslint-disable-next-line array-callback-return
-      let yearFilter = null
-      const langFilters = []
       this.params.filters.forEach((filter) => {
         const { field, value } = filter
         switch (field) {
@@ -421,30 +444,92 @@ class Search {
               if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
               dateRange.relation = 'WITHIN'
               yearFilter = ['range', 'instances.pub_date', dateRange]
+              this.dateFilterRange = dateRange
             }
             break
           case 'language':
             this.logger.debug(`Filtering works by language ${value}`)
             langFilters.push(['nested', { path: 'instances.language', query: { term: { 'instances.language.language': value } } }])
             break
+          case 'show_all':
+            this.logger.debug('Disabling works return filter')
+            if (value) {
+              readFilter = null
+              this.show_all_works = true
+            }
+            break
           default:
             this.logger.warning('API Not configured to handle this filter')
             break
         }
       })
-      if (yearFilter || langFilters.length > 0) {
+    }
+    if (readFilter || yearFilter || langFilters.length > 0) {
+      if (langFilters.length <= 1) {
         this.query.query('nested', { path: 'instances', inner_hits: { size: 100 } }, (q) => {
-          if (yearFilter) { q.query(...yearFilter) }
-          if (langFilters.length > 0) {
-            q.query('bool', (a) => {
-              langFilters.forEach(lang => a.orQuery(...lang))
-              return a
-            })
-          }
+          Search.createFilterObject(q, yearFilter, readFilter, langFilters[0])
+          return q
+        })
+      } else if (langFilters.length > 1) {
+        this.query.query('bool', (q) => {
+          this.innerSet = false
+          this.setMultipleLangFilters(q, langFilters, yearFilter, readFilter)
           return q
         })
       }
     }
+  }
+
+  /**
+   * Sets multiple filter groups when multiple languages are received. This allows
+   * for multiple instances within each work to be matched when they contain a single
+   * filtered language, rather than both. To do so all other instance filters must
+   * be applied as well.
+   *
+   * To do so while maintaining the inner_hits setting, for instance level filtering,
+   * this must insure that the setting is only applied to the first filter group, from
+   * which it is reflected to all subsequent filter groups.
+   *
+   * @param {Object} parent BodyBuilder ElasticSearch queryObject
+   * @param {Array} yearFilter Array of year filter options
+   * @param {Array} readFilter Array of show_all filter options
+   * @param {Array} langFilters Array of language filters
+   */
+  setMultipleLangFilters(parent, langFilters, yearFilter, readFilter) {
+    langFilters.forEach((filt) => {
+      const nestedPath = { path: 'instances' }
+      if (this.innerSet) {
+        nestedPath.inner_hits = { size: 100 }
+        this.innerSet = true
+      }
+      parent.query('nested', nestedPath, (x) => {
+        x.query('bool', (y) => {
+          Search.createFilterObject(y, yearFilter, readFilter, filt)
+          return y
+        })
+        return x
+      })
+    })
+  }
+
+  /**
+   * This appends a single set of filter objects to the ElasticSearch query.
+   * These filters are dependent on each other so must be added as a group, as
+   * they are all nested within the instances array. Other filters, will not
+   * be included in this group
+   *
+   * @param {Object} parent BodyBuilder ElasticSearch queryObject
+   * @param {Array} yearFilt Array of year filter options
+   * @param {Array} readFilt Array of show_all filter options
+   * @param {Array} langFilt Array of language filter options
+   *
+   * @returns {Object} Updated BodyBuilder query object
+   */
+  static createFilterObject(parent, yearFilt, readFilt, langFilt) {
+    if (yearFilt) { parent.query(...yearFilt) }
+    if (readFilt) { parent.query(...readFilt) }
+    if (langFilt && langFilt.length > 0) { parent.query(...langFilt) }
+    return parent
   }
 
   /**
@@ -455,11 +540,78 @@ class Search {
    * specific to each field and must be custom-defined within this method
    */
   addAggregations() {
+    const aggs = []
     // Add aggregation for language facet
-    const langFacet = 'language'
-    this.query.agg('nested', { path: 'language' }, langFacet, a => a.agg('terms', 'language.language', { size: 200 }))
+    aggs.push(Search.createLangAgg())
 
-    this.query.agg('nested', { path: 'instances.language' }, langFacet, a => a.agg('terms', 'instances.language.language', { size: 200 }, langFacet, b => b.agg('reverse_nested', {}, langFacet)))
+    aggs.forEach((agg) => {
+      this.query.agg(...agg[0], (a) => {
+        Search.createAgg(a, agg, 1)
+        return a
+      })
+    })
+  }
+
+  /**
+   * Appends a new nested layer to the current aggregation object
+   *
+   * @param {Array} aggArray Array of aggregation options
+   * @param {Array} layer Options for the current aggregation being added
+   * @param {Integer} pos Current count of aggregation options that have been added
+   *
+   * @returns {Integer} The increased position counter for the next layer
+   */
+  static addAggLayer(aggArray, layer, pos) {
+    // eslint-disable-next-line no-param-reassign
+    const newPos = pos + 1
+    layer.push(`language_${newPos}`)
+    aggArray.push(layer)
+    return newPos
+  }
+
+  /**
+   * Builds the aggregation object for the language facet. This includes optional
+   * aggregation layers for the show_all_works option and the date range filter.
+   * Future facets will potentially need to be aded as well as options
+   *
+   * @returns {Array} The array of aggregation layers to be transformed to an aggregation object
+   */
+  static createLangAgg() {
+    // eslint-disable-next-line no-unused-vars
+    let pos = 0
+    const langAggOptions = []
+    pos = Search.addAggLayer(langAggOptions, ['nested', { path: 'instances' }], pos)
+
+    if (!this.show_all_works) {
+      pos = Search.addAggLayer(langAggOptions, ['nested', { path: 'instances.items' }], pos)
+      pos = Search.addAggLayer(langAggOptions, ['filter', { exists: { field: 'instances.items.source' } }], pos)
+      pos = Search.addAggLayer(langAggOptions, ['reverse_nested', { path: 'instances' }], pos)
+    }
+
+    if (this.dateFilterRange) {
+      pos = Search.addAggLayer(langAggOptions, ['filter', { range: { 'instances.pub_date': this.dateFilterRange } }], pos)
+    }
+
+    pos = Search.addAggLayer(langAggOptions, ['nested', { path: 'instances.language' }], pos)
+    pos = Search.addAggLayer(langAggOptions, ['terms', { field: 'instances.language.language', size: 200 }], pos)
+    pos = Search.addAggLayer(langAggOptions, ['reverse_nested', {}], pos)
+
+    return langAggOptions
+  }
+
+  /**
+   * Converts an aggregation layer to a nested object within the aggregation object
+   * @param {Object} query The parent query object
+   * @param {Array} agg The current set of aggregation options for this layer
+   * @param {Integer} pos The position of the current layer in the aggregations array
+   */
+  static createAgg(query, agg, pos) {
+    if (!agg[pos]) { return null }
+    const newPos = pos + 1
+    return query.agg(...agg[pos], (sub) => {
+      Search.createAgg(sub, agg, newPos)
+      return sub
+    })
   }
 }
 

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -685,13 +685,13 @@
       "properties": {
         "field": {
           "type": "string",
-          "enum": ["language", "years"],
+          "enum": ["language", "years", "show_all"],
           "description": "Field on which to match results by (effectively exact-match search)"
         },
         "value": {
           "type": "object",
           "$ref": "#/definitions/FilterObject",
-          "description": "Value on which to filter. Can be a string (for term filters), or an object such as {start: 1900, end: 2000} for years"
+          "description": "Value on which to filter. Can be a string (for term filters such as language), a boolean value (for show_all), or an object such as {start: 1900, end: 2000} for years"
         }
       },
       "example": [


### PR DESCRIPTION
Implements a `show_all` filter, disabled by default, which controls which `works`/`instances` are displayed based off the availability of "readable" `items`. These can be either HTML pages or epub files available online or downloadable PDF files. The `show_all` filter acepts a boolean value and if set to `true` will return ALL `instances` for `works` regardless of their readability.

Implementing this feature introduced some complexity to the filter and aggregation methods in the `Search` class and as a result they were refactored somewhat to gain the following effects:

- The `filter` methods were altered to allow for grouping of related filters together in logical blocks. This allows for related filters to be applied together and ensure that only `instances` that match all set filters are returned. For example, all of the current filter options apply within `instances` and this allows them to be set within a single `nested` block and applied simultaneously.
- Some filters are applied in "parallel" such as the `language` filters, which when multiple languages are applied constructs one filter block for each language. This allows `instances` that match a single language to be returned if that `instance` also matches the other supplied filter criteria.
- The aggregations options have been refactored to allow for the recursive building of aggregation objects. Each individual aggregation will have its own constructor method, which builds an array of aggregation options. These are then recursively itereated to build the ElasticSearch aggregation object. These arrays are comprised of settings that can either set filter options for the agg or `nested` or `reverse_nested` options which traverse the aggregation context to allow setting filters at different levels.