### PR TITLE
SFR-288 Add multiple query option to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,35 @@ After initialization, if this is a new application, run `eb create` to create th
 
 ## Searching
 
-The `search` endpoint supports both `GET` and `POST` requests with the same basic parameters. Required are:
+The `search` endpoint supports both `GET` and `POST` requests with the same basic parameters. Queries can be both for an individual term or an array of terms. In either case the main `query` object must be comprised of the following:
 
 - `field` the field(s) you would like to search. Currently supported are `keyword`, `title`, `author` and `subject`.
 - `query` the string you would like to search. The query field supports boolean search construction as well as quotation marks for exact term matching.
+
+For example a simple search query looks like:
+
+``` json
+{
+    "field": "keyword",
+    "query": "history"
+}
+```
+
+A more complex query looks like:"
+
+``` json
+{
+    "queries": [
+        {
+            "field": "keyword",
+            "query": "New York City"
+        },{
+            "field": "subject",
+            "query": "history"
+        }
+    ]
+}
+```
 
 ### Search Fields
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -254,17 +254,35 @@ class Search {
     this.query.sort(newSort)
   }
 
-  /**
-   * Create the main ElasticSearch query body utilizing the BodyBuilder library.
-   * Creates the query, sort, filter, and aggregations
-   */
   buildSearch() {
-    if (!('field' in this.params) || !('query' in this.params)) {
-      throw new MissingParamError('Your POST request must include either queries or filters')
+    if (!('queries' in this.params) && !('query' in this.params && 'field' in this.params)) {
+      throw new MissingParamError('Your POST request must include either a query object or an array of queries')
     }
 
-    const { field, query } = this.params
     this.query = bodybuilder()
+
+    if ('query' in this.params) {
+      const { field, query } = this.params
+      this.buildQuery(field, query)
+    } else {
+      const { queries } = this.params
+      queries.forEach((q) => {
+        const { field, query } = q
+        this.buildQuery(field, query)
+      })
+    }
+
+    this.queryCount = this.query.build()
+
+    this.addFilters()
+    this.addSort()
+    this.addAggregations()
+  }
+
+  buildQuery(field, query) {
+    if (!field || !query) {
+      throw new MissingParamError('Each query object in your request must contain query and field fields')
+    }
 
     // Catch case where escape character has been escaped and reduce to a single escape character
     const queryTerm = query.replace(/[\\]+([^\w\s]{1})/g, '\\$1')
@@ -331,11 +349,6 @@ class Search {
             .orQuery('nested', { path: 'instances.items', query: { query_string: { query: queryTerm, default_operator: 'and' } } })))
         break
     }
-    this.queryCount = this.query.build()
-
-    this.addFilters()
-    this.addSort()
-    this.addAggregations()
   }
 
   /**

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -579,12 +579,18 @@
           "description": "Field to query. Currently supports: Keyword, Title, Author and Subject. Defaults to Keyword",
           "type": "string",
           "example": "keyword",
-          "enum": ["keyword", "title", "author", "subject"]
+          "enum": ["keyword", "title", "author", "subject", "viaf", "lcnaf"]
         },
         "query": {
           "description": "Query term to search. This is a free-text field and which understands standard boolean search terms as well as quoted strings for exact matching.",
-          "example": "\"Personal Anecodotes\" OR narrative",
+          "example": "\"Civil War\" OR Lincoln",
           "type": "string"
+        },
+        "queries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v2QueryBlock"
+          }
         },
         "filters": {
           "type": "array",
@@ -717,6 +723,23 @@
           "type": "string",
           "example": "divina",
           "description": "Query value"
+        }
+      }
+    },
+    "v2QueryBlock": {
+      "title": "v2 Query",
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "example": "keyword",
+          "description": "Field to query",
+          "enum": ["keyword", "title", "author", "subject", "viaf", "lcnaf"]
+        },
+        "query": {
+          "type": "string",
+          "example": "\"Civil War\" OR Lincoln",
+          "description": "Text of the query. Can contain standard boolean search syntax"
         }
       }
     },


### PR DESCRIPTION
This adds the option for users to pass multiple `query` objects as search parameters to the main search endpoint. This enables a multi-field advanced search option. This takes the form of a `queries` array of objects that must contain `field` and `query` fields, the same as the single query search option.

At present these terms are joined with AND, though this will be made user-configurable later on.

Minor refactoring of the `Search` class took place to enable this option and return logical error messages in the case of missing parameters.