### PR TITLE
SFR-47 implement language util endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,11 @@ The `work` endpoint also supports both `GET` and `POST` requests and returns a s
 UUID is preferred as it is the only identifier that is guaranteed to only return a single record.
 
 If no results or multiple results are found for an identifier, this will return a non-200 error message.
+
+## Utilities
+
+The API also supports a `utils` route that can provide additional functionality that supports the core functionality of the API. These endpoints will return statistics, specific pieces of data from the collection or other small functions that can help support large functionality. Each existing utility endpoint will be detailed in this section
+
+### Language List: (`utils/languages`) [`GET`]
+
+This endpoint returns a list of all languages that currently exist in the ResearchNow database. This allows the advanced search interface to present users with an array of all languages they might filter their results by. This accepts a single query parameter: `total` which accepts a boolean value (`false` by default) and which returns the total count of `Work` records associated with each language when enabled. This allows API users to quickly obtain a list of `Work` counts by language, enabling insights into the data and potential use as a visualization/feature.

--- a/routes/v2/utils.js
+++ b/routes/v2/utils.js
@@ -43,7 +43,7 @@ const fetchLangs = (app, params) => {
   const { total } = params
 
   // Construct the ElasticSearch query using the BodyBuilder library
-  const body = buildQuery(total)
+  const body = module.exports.buildQuery(total)
 
   // Create an object that can be understood by the ElasticSearch service
   const esQuery = {
@@ -52,7 +52,7 @@ const fetchLangs = (app, params) => {
   }
 
   // Execute ElasticSearch query
-  return execQuery(app, esQuery, total)
+  return module.exports.execQuery(app, esQuery, total)
 }
 
 /**
@@ -92,19 +92,18 @@ const buildQuery = (total) => {
  * @param {Object} esQuery Object containing ES index and built query object
  * @param {Boolean} total Toggle for the return of total works associated with each language
  */
-const execQuery = (app, esQuery, total) => {
-  return new Promise((resolve, reject) => {
+const execQuery = (app, esQuery, total) => (
+  new Promise((resolve, reject) => {
     app.client.search(esQuery)
       .then((resp) => {
         // Raise an error if no aggregations were returned
         const docCount = resp.aggregations.language_inner.doc_count
         if (docCount < 1) reject(new ElasticSearchError('Could not load language aggregations'))
-        const langArray = parseLanguageAgg(resp.aggregations.language_inner, total)
+        const langArray = module.exports.parseLanguageAgg(resp.aggregations.language_inner, total)
         resolve(langArray)
       })
       .catch(error => reject(error))
-  })
-}
+  }))
 
 /**
  * Parses the aggregation received from ElasticSearch
@@ -140,4 +139,11 @@ const formatLanguageResponse = langArr => (
   }
 )
 
-module.exports = { utilEndpoints }
+module.exports = {
+  utilEndpoints,
+  fetchLangs,
+  buildQuery,
+  execQuery,
+  parseLanguageAgg,
+  formatLanguageResponse,
+}

--- a/routes/v2/utils.js
+++ b/routes/v2/utils.js
@@ -1,0 +1,143 @@
+const bodybuilder = require('bodybuilder')
+const { ElasticSearchError } = require('../../lib/errors')
+
+/**
+ * Handler function for utility endpoints. These will provide various supporting
+ * services for the ResearchNow API, at present it provides a utility for viewing
+ * all of the languages with works in the database.
+ *
+ * @param {Object} app Express application
+ * @param {Function} respond Express response method
+ * @param {Function} handleError Express error handler
+ */
+const utilEndpoints = (app, respond, handleError) => {
+  /**
+   * Language response utility. Responds with an array of existing languages. If
+   * total exists as a query parameter, the total count of works for each language
+   * will be returned.
+   */
+  app.get('/sfr/utils/languages', async (req, res) => {
+    const params = req.query
+    try {
+      const langArray = await fetchLangs(app, params)
+      const langRes = formatLanguageResponse(langArray)
+      respond(res, langRes, params)
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+}
+
+/**
+ * The main function that builds the language array query and returns the raw
+ * ElasticSearch response. This uses the ES aggregations function to retrieve
+ * a distinct array of languages in the database, with (optionally) counts of the
+ * number of works associated with each language.
+ *
+ * @param {Object} app Express application
+ * @param {Object} params Query parameters
+ *
+ * @returns {Object} The raw ElasticSearch response resolved by execQuery()
+ */
+const fetchLangs = (app, params) => {
+  const { total } = params
+
+  // Construct the ElasticSearch query using the BodyBuilder library
+  const body = buildQuery(total)
+
+  // Create an object that can be understood by the ElasticSearch service
+  const esQuery = {
+    index: process.env.ELASTICSEARCH_INDEX_V2,
+    body: body.build(), // Translates bodybuilder object into nested object
+  }
+
+  // Execute ElasticSearch query
+  return execQuery(app, esQuery, total)
+}
+
+/**
+ * Utilizes BodyBuilder to created a nested query, which includes a "match_all" query
+ * and an aggregation object with gathers all distinct languages (from the nested
+ * fields associated with the instance records)
+ *
+ * @param {Boolean} total Toggle to control return of count of associated works with each language
+ *
+ * @returns {Object} A bodybuilder query object containing the language aggregation
+ */
+const buildQuery = (total) => {
+  const body = bodybuilder()
+  body.query('match_all', {})
+  body.size(0)
+
+  body.agg('nested', { path: 'instances.language' }, 'language_inner', (a) => {
+    a.agg('terms', { field: 'instances.language.language', size: 250 }, 'unique_languages', (b) => {
+      // If total is set, an additional aggregation is necessary to count the root works
+      if (total) {
+        b.agg('reverse_nested', {}, 'inner_count')
+      }
+      return b
+    })
+    return a
+  })
+
+  return body
+}
+
+/**
+ * Executes an ElasticSearch query and returns the results. If no documents are
+ * associated with the aggregation object an error occured. Otherwise the raw
+ * ElasticSearch response is returned
+ *
+ * @param {Object} app Express application
+ * @param {Object} esQuery Object containing ES index and built query object
+ * @param {Boolean} total Toggle for the return of total works associated with each language
+ */
+const execQuery = (app, esQuery, total) => {
+  return new Promise((resolve, reject) => {
+    app.client.search(esQuery)
+      .then((resp) => {
+        // Raise an error if no aggregations were returned
+        const docCount = resp.aggregations.language_inner.doc_count
+        if (docCount < 1) reject(new ElasticSearchError('Could not load language aggregations'))
+        const langArray = parseLanguageAgg(resp.aggregations.language_inner, total)
+        resolve(langArray)
+      })
+      .catch(error => reject(error))
+  })
+}
+
+/**
+ * Parses the aggregation received from ElasticSearch
+ * @param {Object} mainAgg The root aggregation object received from ElasticSearch
+ * @param {Boolean} total Toggle for the return of total works assocaited with each language
+ *
+ * @returns {Array} The array of unique languages with (optionally) the total works
+ * associated with each
+ */
+const parseLanguageAgg = (mainAgg, total) => {
+  const { buckets } = mainAgg.unique_languages
+  return buckets.map((bucket) => {
+    const lang = { language: bucket.key }
+    if (total) { lang.count = bucket.inner_count.doc_count }
+    return lang
+  })
+}
+
+/**
+ * Simple method for formatting array of unique languages as a response that can
+ * returned to the user via the API
+ *
+ * @param {Array} langArr Formatted array of unique languages
+ *
+ * @returns {Object} Response object with standard status and data fields
+ */
+const formatLanguageResponse = langArr => (
+  {
+    status: 200,
+    data: {
+      languages: langArr,
+    },
+  }
+)
+
+module.exports = { utilEndpoints }

--- a/routes/v2/v2.js
+++ b/routes/v2/v2.js
@@ -4,6 +4,7 @@ const logger = require('../../lib/logger')
 const pjson = require('../../package.json')
 const { searchEndpoints } = require('./search')
 const { workEndpoints } = require('./work')
+const { utilEndpoints } = require('./utils')
 
 // Create an instance of an Express router to handle requests to v2 of the API
 const v2Router = express.Router()
@@ -73,5 +74,6 @@ const handleError = (res, error) => {
 // Load endpoints
 searchEndpoints(v2Router, respond, handleError)
 workEndpoints(v2Router, respond, handleError)
+utilEndpoints(v2Router, respond, handleError)
 
 module.exports = { v2Router, respond, handleError }

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -491,6 +491,56 @@
           }
         }
       }
+    },
+    "/v0.1/research-now/v2/utils/languages": {
+      "get": {
+        "tags": [
+          "research-now"
+        ],
+        "summary": "(v2) GET Distinct Language Lookup",
+        "description": "Returns an array of unique languages in the ResearchNow database",
+        "parameters": [
+          {
+            "name": "total",
+            "in": "query",
+            "description": "Toggle, if true will return total number of works associated with each language",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON object containing the languages array",
+            "schema": {
+              "$ref": "#/definitions/LanguageResponse"
+            }
+          },
+          "404": {
+            "description": "Resource was not found error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "An Invalid Parameter was recieved in the Request",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "default": {
+            "description": "Unexpected Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -720,6 +770,50 @@
         }
       }
     },
-    "FilterObject": {}
+    "FilterObject": {},
+    "LanguageResponse": {
+      "title": "Language Utility Response",
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "integer",
+          "example": "200",
+          "description": "API status code"
+        },
+        "data": {
+          "type": "object",
+          "$ref": "#/definitions/LanguageData",
+          "description": "Data block for the language utility"
+        }
+      }
+    },
+    "LanguageData": {
+      "title": "Language Data Block",
+      "type": "object",
+      "properties": {
+        "languages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LanguageObject"
+          }
+        }
+      }
+    },
+    "LanguageObject": {
+      "title": "Language Object",
+      "type": "object",
+      "properties": {
+        "language": {
+          "type": "string",
+          "example": "Spanish",
+          "description": "Full text string of the language"
+        },
+        "count": {
+          "type": "integer",
+          "example": "10",
+          "description": "Count of the number of works associated with this language"
+        }
+      }
+    }
   }
 }

--- a/test/swaggerDocs.test.js
+++ b/test/swaggerDocs.test.js
@@ -34,7 +34,7 @@ describe('Testing Swagger Documentation', () => {
       .then((resp) => {
         const apiPaths = []
         Object.keys(resp.body.paths).map(path => apiPaths.push(path))
-        expect(apiPaths.length).to.equal(5)
+        expect(apiPaths.length).to.equal(6)
       })
   })
 })

--- a/test/v2Utils.test.js
+++ b/test/v2Utils.test.js
@@ -1,0 +1,218 @@
+/* eslint-disable no-undef */
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const chaiPromise = require('chai-as-promised')
+
+chai.should()
+chai.use(sinonChai)
+chai.use(chaiPromise)
+const { expect } = chai
+
+const Utils = require('../routes/v2/utils')
+const { ElasticSearchError } = require('../lib/errors')
+
+describe('v2 utility endpoints', () => {
+  describe('language list utility', () => {
+    describe('fetchLangs()', () => {
+      it('should call execQuery() with ES query', (done) => {
+        const buildStub = sinon.stub(Utils, 'buildQuery')
+        const execQuery = sinon.stub(Utils, 'execQuery')
+        const bodyStub = sinon.fake()
+        bodyStub.build = () => 'testBodyBuild'
+        buildStub.returns(bodyStub)
+
+        const checkQuery = {
+          index: process.env.ELASTICSEARCH_INDEX_V2,
+          body: 'testBodyBuild',
+        }
+
+        Utils.fetchLangs('app', { total: true })
+        expect(buildStub).to.have.been.calledOnceWith(true)
+        expect(execQuery).to.have.been.calledOnceWith('app', checkQuery, true)
+        buildStub.restore()
+        execQuery.restore()
+        done()
+      })
+    })
+
+    describe('buildQuery()', () => {
+      it('should build query with inner_count if total is true', (done) => {
+        const testBody = Utils.buildQuery(true).build()
+        expect(testBody.size).to.equal(0)
+        expect(testBody.query).to.deep.equal({ match_all: {} })
+        expect(testBody.aggs.language_inner.aggs.unique_languages.terms.field).to.equal('instances.language.language')
+        expect(testBody.aggs.language_inner.aggs.unique_languages.terms.size).to.equal(250)
+        const innerCount = testBody.aggs.language_inner.aggs.unique_languages.aggs.inner_count
+        expect(innerCount).to.deep.equal({ reverse_nested: {} })
+        done()
+      })
+
+      it('should build query without inner_count if total is false-y', (done) => {
+        const testBody = Utils.buildQuery(false).build()
+        expect(testBody.size).to.equal(0)
+        expect(testBody.query).to.deep.equal({ match_all: {} })
+        expect(testBody.aggs.language_inner.aggs.unique_languages.terms.field).to.equal('instances.language.language')
+        expect(testBody.aggs.language_inner.aggs.unique_languages.terms.size).to.equal(250)
+        // eslint-disable-next-line no-unused-expressions
+        expect(testBody.aggs.language_inner.aggs.unique_languages.aggs).to.be.undefined
+        done()
+      })
+    })
+
+    describe('execQuery()', () => {
+      let parseStub = null
+      beforeEach(() => {
+        parseStub = sinon.stub(Utils, 'parseLanguageAgg')
+      })
+
+      afterEach(() => {
+        parseStub.restore()
+      })
+
+      it('should return language array on successful query', async () => {
+        const testResp = {
+          hits: {
+            total: 10,
+            max_score: 0,
+            hits: [],
+          },
+          aggregations: {
+            language_inner: {
+              doc_count: 10,
+              unique_languages: {
+                buckets: [
+                  {
+                    key: 'Test1',
+                    inner_count: {
+                      doc_count: 5,
+                    },
+                  }, {
+                    key: 'Test2',
+                    inner_count: {
+                      doc_count: 3,
+                    },
+                  }, {
+                    key: 'Test3',
+                    inner_count: {
+                      doc_count: 2,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }
+        const fakeApp = sinon.fake()
+        const fakeClient = sinon.fake()
+        const fakeSearch = sinon.fake.resolves(testResp)
+        fakeClient.search = fakeSearch
+        fakeApp.client = fakeClient
+        parseStub.returns(testResp.aggregations.language_inner.unique_languages.buckets)
+
+        const execResp = await Utils.execQuery(fakeApp, {}, true)
+        expect(execResp).to.be.instanceOf(Array)
+        expect(execResp[1].key).to.equal('Test2')
+        expect(execResp[0].inner_count.doc_count).to.equal(5)
+      })
+
+      it('should raise ElasticSearchError if no docs are returned', async () => {
+        const testResp = {
+          hits: {
+            total: 0,
+            max_score: 0,
+            hits: [],
+          },
+          aggregations: {
+            language_inner: {
+              doc_count: 0,
+              unique_language: {
+                buckets: [],
+              },
+            },
+          },
+        }
+        const fakeApp = sinon.fake()
+        const fakeClient = sinon.fake()
+        const fakeSearch = sinon.fake.resolves(testResp)
+        fakeClient.search = fakeSearch
+        fakeApp.client = fakeClient
+        const result = Utils.execQuery(fakeApp, {}, true)
+        expect(result).to.eventually.throw(new ElasticSearchError('Could not load language aggregations'))
+        // eslint-disable-next-line no-unused-expressions
+        expect(parseStub).to.not.be.called
+      })
+
+      it('should reject on a generic error', async () => {
+        const testResp = {
+          error: 'testError',
+        }
+        const fakeApp = sinon.fake()
+        const fakeClient = sinon.fake()
+        const fakeSearch = sinon.fake.rejects(testResp)
+        fakeClient.search = fakeSearch
+        fakeApp.client = fakeClient
+        try {
+          await Utils.execQuery(fakeApp, {}, true)
+        } catch (err) {
+          expect(err).to.be.instanceOf(Error)
+        }
+        // eslint-disable-next-line no-unused-expressions
+        expect(parseStub).to.not.be.called
+      })
+    })
+
+    describe('parseLanguageAgg()', () => {
+      let testAggs = null
+      beforeEach(() => {
+        testAggs = {
+          unique_languages: {
+            buckets: [
+              {
+                key: 'Test1',
+                inner_count: {
+                  doc_count: 5,
+                },
+              }, {
+                key: 'Test2',
+                inner_count: {
+                  doc_count: 3,
+                },
+              }, {
+                key: 'Test3',
+                inner_count: {
+                  doc_count: 2,
+                },
+              },
+            ],
+          },
+        }
+      })
+
+      afterEach(() => {})
+
+      it('should return array of languages without totals it total is false', (done) => {
+        const testArray = Utils.parseLanguageAgg(testAggs, false)
+        expect(testArray[0]).to.deep.equal({ language: 'Test1' })
+        expect(testArray[2]).to.deep.equal({ language: 'Test3' })
+        done()
+      })
+
+      it('should return array of languages with totals it total is true', (done) => {
+        const testArray = Utils.parseLanguageAgg(testAggs, true)
+        expect(testArray[0]).to.deep.equal({ language: 'Test1', count: 5 })
+        expect(testArray[2]).to.deep.equal({ language: 'Test3', count: 2 })
+        done()
+      })
+    })
+
+    describe('formatLanguageResponse()', () => {
+      it('should return respone object containing array', (done) => {
+        const testResp = Utils.formatLanguageResponse('testArray')
+        expect(testResp.status).to.equal(200)
+        expect(testResp.data.languages).to.equal('testArray')
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This creates a new route `utils` for various utility endpoints to exist at. This branch creates one such endpoint: `utils/languages` which returns an array of all languages in the database.

This accepts a single query parameter: `total` which when set to `true` includes the total number of `Work` records associated with each language.

This is initially intended to support the advanced search feature, but could be used by other tools in the future, including a feature to count `Work` records on the homepage or another visualization.