### PR TITLE
SFR-48 Add Format Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ Filtering is supported on a set of pre-defined fields. At present the following 
 - `language`: Filters results to return only works matching the provided language
 - `years`: Filters results to return only works with publication dates based off the provided range. This is calculated from the publication dates associated with the editions for each work. This should be formatted as `{"start": year, "end": year}`.
 - `show_all`: By default, the search results only include works with editions that have readable copies (either downloadable or available to read online). Setting this value to `true` will return all works, regardless of this status, in the search results.
+- `format`: Filters results to return only works that contain `Item` records with links to the specified ebook formats The current valid options for this format are:
+  
+  - `pdf`
+  - `epub`
+  - `html`
 
 ## Aggregations/Facets
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -20,7 +20,19 @@ function MissingParamError(message) {
 
 MissingParamError.prototype = Error.prototype
 
+function InvalidFilterError(message) {
+  if (!message || typeof message !== 'string' || message.trim() === '') {
+    throw new Error('error message is required')
+  }
+
+  this.message = message
+  this.name = 'InvalidFilterError'
+}
+
+InvalidFilterError.prototype = Error.prototype
+
 module.exports = {
   ElasticSearchError,
   MissingParamError,
+  InvalidFilterError,
 }

--- a/lib/search.js
+++ b/lib/search.js
@@ -457,22 +457,48 @@ class Search {
         const { field, value } = filter
         switch (field) {
           case 'years':
-            if (value.start !== '' || value.end !== '') {
-              this.logger.debug(`Filtering works by years ${value.start} to ${value.end}`)
-              // eslint-disable-next-line no-case-declarations
-              const dateRange = {}
-              if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
-              if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
-              dateRange.relation = 'WITHIN'
-              yearFilter = ['range', 'instances.pub_date', dateRange]
-              this.dateFilterRange = dateRange
+            if (!(typeof value === 'object')) {
+              throw new InvalidFilterError('years filter value must be an object')
+            } else if (!('start' in value || 'end' in value)) {
+              throw new InvalidFilterError('years filter must contain a start or end value (or both)')
+            } else if ((value.start === '' || value.start === undefined) && (value.end === '' || value.end === undefined)) {
+              throw new InvalidFilterError('start or end field in years filter must contain a value')
             }
+            Object.keys(value).forEach((key) => {
+              const yearCheck = Number(value[key])
+              // eslint-disable-next-line no-restricted-globals
+              if (isNaN(yearCheck)) {
+                throw new InvalidFilterError(`years filter ${key} value ${value[key]} is not a valid year`)
+              } else if (yearCheck === 0) {
+                delete value[key]
+              } else {
+                value[key] = yearCheck
+              }
+            })
+
+            if (value.start && value.end) {
+              if (value.end < value.start) {
+                throw new InvalidFilterError(`end year ${value.end} must be greater than start year ${value.start}`)
+              }
+            }
+
+            this.logger.debug(`Filtering works by years ${value.start} to ${value.end}`)
+            // eslint-disable-next-line no-case-declarations
+            const dateRange = {}
+            if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
+            if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
+            dateRange.relation = 'WITHIN'
+            yearFilter = ['range', 'instances.pub_date', dateRange]
+            this.dateFilterRange = dateRange
             break
           case 'language':
             this.logger.debug(`Filtering works by language ${value}`)
             langFilters.push(['nested', { path: 'instances.language', query: { term: { 'instances.language.language': value } } }])
             break
           case 'show_all':
+            if (!(typeof value === 'boolean')) {
+              throw new InvalidFilterError('The show_all filter only accepts boolean values')
+            }
             this.logger.debug('Disabling works return filter')
             if (value) {
               readFilter = null
@@ -488,8 +514,8 @@ class Search {
             this.formats.push(formatFilterTrans[value])
             break
           default:
-            this.logger.warning('API Not configured to handle this filter')
-            break
+            this.logger.error('API Not configured to handle this filter')
+            throw new InvalidFilterError(`${field} is not a valid filter option`)
         }
       })
     }

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,5 +1,5 @@
 const bodybuilder = require('bodybuilder')
-const { MissingParamError } = require('./errors')
+const { MissingParamError, InvalidFilterError } = require('./errors')
 const Helpers = require('../helpers/esSourceHelpers')
 
 /*
@@ -15,6 +15,12 @@ const blacklistRoles = ['arl', 'binder', 'binding designer', 'book designer',
   'publishing director', 'retager', 'secretary', 'sponsor', 'stereotyper',
   'thesis advisor', 'transcriber', 'typographer', 'woodcutter',
 ]
+
+const formatFilterTrans = {
+  epub: 'application/epub+zip',
+  pdf: 'application/pdf',
+  html: 'text/html',
+}
 
 /** Class representing a search object. */
 class Search {
@@ -441,6 +447,8 @@ class Search {
    */
   addFilters() {
     let yearFilter = null
+    let formatFilter = null
+    this.formats = []
     let readFilter = ['nested', { path: 'instances.items', query: { exists: { field: 'instances.items.source' } } }]
     const langFilters = []
     if ('filters' in this.params && this.params.filters instanceof Array) {
@@ -471,22 +479,35 @@ class Search {
               this.show_all_works = true
             }
             break
+          case 'format':
+            this.logger.debug(`Filtering works by format ${value}`)
+            if (!(value in formatFilterTrans)) {
+              this.logger.error(`Received invalid format filter value: ${value}`)
+              throw new InvalidFilterError(`Format filter value (${value}) must be one of the following: pdf, epub or html`)
+            }
+            this.formats.push(formatFilterTrans[value])
+            break
           default:
             this.logger.warning('API Not configured to handle this filter')
             break
         }
       })
     }
-    if (readFilter || yearFilter || langFilters.length > 0) {
+
+    if (this.formats.length > 0) {
+      formatFilter = ['nested', { path: 'instances.items.links', query: { terms: { 'instances.items.links.media_type': this.formats } } }]
+    }
+
+    if (readFilter || yearFilter || formatFilter || langFilters.length > 0) {
       if (langFilters.length <= 1) {
         this.query.query('nested', { path: 'instances', inner_hits: { size: 100 } }, (q) => {
-          Search.createFilterObject(q, yearFilter, readFilter, langFilters[0])
+          Search.createFilterObject(q, yearFilter, readFilter, formatFilter, langFilters[0])
           return q
         })
       } else if (langFilters.length > 1) {
         this.query.query('bool', (q) => {
           this.innerSet = false
-          this.setMultipleLangFilters(q, langFilters, yearFilter, readFilter)
+          this.setMultipleLangFilters(q, langFilters, formatFilter, yearFilter, readFilter)
           return q
         })
       }
@@ -506,9 +527,10 @@ class Search {
    * @param {Object} parent BodyBuilder ElasticSearch queryObject
    * @param {Array} yearFilter Array of year filter options
    * @param {Array} readFilter Array of show_all filter options
+   * @param {Array} formatFilter Array of format filter options
    * @param {Array} langFilters Array of language filters
    */
-  setMultipleLangFilters(parent, langFilters, yearFilter, readFilter) {
+  setMultipleLangFilters(parent, langFilters, formatFilter, yearFilter, readFilter) {
     langFilters.forEach((filt) => {
       const nestedPath = { path: 'instances' }
       if (!this.innerSet) {
@@ -517,7 +539,7 @@ class Search {
       }
       parent.query('nested', nestedPath, (x) => {
         x.query('bool', (y) => {
-          Search.createFilterObject(y, yearFilter, readFilter, filt)
+          Search.createFilterObject(y, yearFilter, readFilter, formatFilter, filt)
           return y
         })
         return x
@@ -534,13 +556,15 @@ class Search {
    * @param {Object} parent BodyBuilder ElasticSearch queryObject
    * @param {Array} yearFilt Array of year filter options
    * @param {Array} readFilt Array of show_all filter options
+   * @param {Array} formatFilt Array of format filter options
    * @param {Array} langFilt Array of language filter options
    *
    * @returns {Object} Updated BodyBuilder query object
    */
-  static createFilterObject(parent, yearFilt, readFilt, langFilt) {
+  static createFilterObject(parent, yearFilt, readFilt, formatFilt, langFilt) {
     if (yearFilt) { parent.query(...yearFilt) }
     if (readFilt) { parent.query(...readFilt) }
+    if (formatFilt) { parent.query(...formatFilt) }
     if (langFilt && langFilt.length > 0) { parent.query(...langFilt) }
     return parent
   }
@@ -603,6 +627,12 @@ class Search {
 
     if (this.dateFilterRange) {
       pos = Search.addAggLayer(langAggOptions, ['filter', { range: { 'instances.pub_date': this.dateFilterRange } }], pos)
+    }
+
+    if (this.formats && this.formats.length > 0) {
+      pos = Search.addAggLayer(langAggOptions, ['nested', { path: 'instances.items.links' }], pos)
+      pos = Search.addAggLayer(langAggOptions, ['filter', { terms: { 'instances.items.links.media_type': this.formats } }], pos)
+      pos = Search.addAggLayer(langAggOptions, ['reverse_nested', { path: 'instances' }], pos)
     }
 
     pos = Search.addAggLayer(langAggOptions, ['nested', { path: 'instances.language' }], pos)

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -741,13 +741,13 @@
       "properties": {
         "field": {
           "type": "string",
-          "enum": ["language", "years", "show_all"],
+          "enum": ["language", "years", "show_all", "format"],
           "description": "Field on which to match results by (effectively exact-match search)"
         },
         "value": {
           "type": "object",
           "$ref": "#/definitions/FilterObject",
-          "description": "Value on which to filter. Can be a string (for term filters such as language), a boolean value (for show_all), or an object such as {start: 1900, end: 2000} for years"
+          "description": "Value on which to filter. Can be a string (for term filters such as language or format), a boolean value (for show_all), or an object such as {start: 1900, end: 2000} for years"
         }
       },
       "example": [


### PR DESCRIPTION
Implements a filter on `format`, the type of ebook that is available to read through ResearchNow. The currently available options are:

- `pdf`
- `epub`
- `html`

A full `format` filter would appear as `{"filters": [{"field": "format", "value": "pdf"}]}`

In addition this adds a new Error class `InvalidFilterError` which has been implemented for all filters. This provides a more understandable error message when invalid filters are received and also prevents ElasticSearch 4XX errors for cases such as date filters with start dates after their end dates.