### PR TITLE
SFR-491 Fix Work Editions

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -592,7 +592,6 @@ class Search {
    * @returns {Object} Updated BodyBuilder query object
    */
   static createFilterObject(parent, yearFilt, readFilt, formatFilt, langFilt) {
-    console.log(yearFilt, readFilt, formatFilt, langFilt)
     if (yearFilt) { parent.query(...yearFilt) }
     if (readFilt) { parent.query(...readFilt) }
     if (formatFilt) { parent.query(...formatFilt) }

--- a/routes/v2/work.js
+++ b/routes/v2/work.js
@@ -73,4 +73,4 @@ const removeInvalidEditions = (source) => {
   ))
 }
 
-module.exports = { fetchWork, workEndpoints }
+module.exports = { fetchWork, workEndpoints, removeInvalidEditions }

--- a/routes/v2/work.js
+++ b/routes/v2/work.js
@@ -53,12 +53,24 @@ const fetchWork = (params, app) => {
         const respCount = resp.hits.hits.length
         if (respCount < 1) reject(new ElasticSearchError('Could not locate a record with that identifier'))
         else if (respCount > 1) reject(new ElasticSearchError('Returned multiple records, identifier lacks specificity'))
+        /* eslint-disable no-underscore-dangle */
+        removeInvalidEditions(resp.hits.hits[0]._source)
         Helpers.formatResponseEditionRange(resp)
-        // eslint-disable-next-line dot-notation
-        resolve(resp.hits.hits[0]['_source'])
+        resolve(resp.hits.hits[0]._source)
+        /* eslint-enable no-underscore-dangle */
       })
       .catch(error => reject(error))
   })
+}
+
+const removeInvalidEditions = (source) => {
+  // eslint-disable-next-line no-param-reassign
+  source.instances = source.instances.filter(ed => (
+    (ed.items && ed.items.length > 0)
+      || ed.pub_date
+      || (ed.agents && ed.agents.length > 0)
+      || ed.pub_place
+  ))
 }
 
 module.exports = { fetchWork, workEndpoints }

--- a/test/v2Work.test.js
+++ b/test/v2Work.test.js
@@ -10,7 +10,7 @@ chai.use(chaiPromise)
 const { expect } = chai
 
 const Helpers = require('../helpers/esSourceHelpers')
-const { fetchWork } = require('../routes/v2/work')
+const { fetchWork, removeInvalidEditions } = require('../routes/v2/work')
 const { ElasticSearchError, MissingParamError } = require('../lib/errors')
 
 describe('v2 single work retrieval tests', () => {
@@ -84,5 +84,35 @@ describe('v2 single work retrieval tests', () => {
     }
     const outcome = fetchWork(params, testApp)
     expect(outcome).to.eventually.throw(ElasticSearchError('Returned multiple records, identifier lacks specificity'))
+  })
+
+  describe('removeInvalidEditions()', () => {
+    it('should remove editions without proper metadata', (done) => {
+      const testSource = {
+        instances: [
+          {
+            items: [
+              'item1',
+            ],
+            pub_date: '2000',
+            agents: [
+              'agent1',
+            ],
+            pub_place: 'nowhere',
+          },
+          {
+            title: 'Empty Record',
+          },
+          {
+            pub_date: '1900',
+            pub_place: 'somewhere',
+          },
+        ],
+      }
+      removeInvalidEditions(testSource)
+      expect(testSource.instances.length).to.equal(2)
+      expect(testSource.instances[1].pub_place).to.equal('somewhere')
+      done()
+    })
   })
 })

--- a/test/v2Work.test.js
+++ b/test/v2Work.test.js
@@ -40,6 +40,7 @@ describe('v2 single work retrieval tests', () => {
             _source: {
               uuid: 1,
               title: 'Test Work',
+              instances: [],
             },
           },
         ],


### PR DESCRIPTION
This minor change implements a new method in the `work` endpoint that returns a single record. This updates the endpoint to function in the same manner as the search endpoint when it comes to invalid editions, filtering out any that lack the necessary metadata to display.

This prevents discrepancies from appearing between the work and instance metadata.