### PR TITLE
SFR-588 add count utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,12 @@ The API also supports a `utils` route that can provide additional functionality 
 ### Language List: (`utils/languages`) [`GET`]
 
 This endpoint returns a list of all languages that currently exist in the ResearchNow database. This allows the advanced search interface to present users with an array of all languages they might filter their results by. This accepts a single query parameter: `total` which accepts a boolean value (`false` by default) and which returns the total count of `Work` records associated with each language when enabled. This allows API users to quickly obtain a list of `Work` counts by language, enabling insights into the data and potential use as a visualization/feature.
+
+### Record Counts: (`utils/totals`) [`GET`]
+
+This returns the total counts of records in the ElasticSearch index in a simple format for easy review/display. By default it will only return a count for `work` records, the most relevant for most users. By passing parameters the following record types can also be displayed. Each can be passed as a simple boolean toggle:
+
+- instances
+- items
+- links
+- subjects

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Simple search API to query the SFR Elasticsearch index.",
   "author": "NYPL Digital",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "dependencies": {
     "@nypl/nypl-data-api-client": "^1.0.0",
     "body-parser": "^1.18.3",

--- a/swagger.v2.json
+++ b/swagger.v2.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "v0.2.3",
+    "version": "v0.2.2",
     "title": "ResearchNow Search API",
     "description": "REST API for Elasticsearch index for the ResearchNow Project"
   },
@@ -541,6 +541,77 @@
           }
         }
       }
+    },
+    "/v0.1/research-now/v2/utils/totals": {
+      "get": {
+        "tags": [
+          "research-now"
+        ],
+        "summary": "(v2) GET Work/Record Counts",
+        "description": "Returns an object of total counts for records in the ElasticSeach index. By default only counts works, but can include others",
+        "parameters": [
+          {
+            "name": "instances",
+            "in": "query",
+            "description": "Toggle, provide to return total count of instances",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "items",
+            "in": "query",
+            "description": "Toggle, provide to return total count of items",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "links",
+            "in": "query",
+            "description": "Toggle, provide to return total count of links",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "subjects",
+            "in": "query",
+            "description": "Toggle, provide to return total count of subjects",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON object containing the record counts",
+            "schema": {
+              "$ref": "#/definitions/TotalResponse"
+            }
+          },
+          "404": {
+            "description": "Resource was not found error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "An Invalid Parameter was recieved in the Request",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "default": {
+            "description": "Unexpected Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -818,6 +889,48 @@
           "type": "integer",
           "example": "10",
           "description": "Count of the number of works associated with this language"
+        }
+      }
+    },
+    "TotalResponse": {
+      "title": "Count Utility Response",
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "integer",
+          "example": "200",
+          "description": "API status code"
+        },
+        "data": {
+          "type": "object",
+          "$ref": "#/definitions/TotalObject",
+          "description": "Data block for the count utility"
+        }
+      }
+    },
+    "TotalObject": {
+      "title": "Total Object",
+      "type": "object",
+      "properties": {
+        "works": {
+          "type": "integer",
+          "description": "Total count of the works"
+        },
+        "instances": {
+          "type": "integer",
+          "description": "Total count of the instances"
+        },
+        "items": {
+          "type": "integer",
+          "description": "Total count of the items"
+        },
+        "links": {
+          "type": "integer",
+          "description": "Total count of the links"
+        },
+        "subjects": {
+          "type": "integer",
+          "description": "Total count of the subjects"
         }
       }
     },

--- a/test/swaggerDocs.test.js
+++ b/test/swaggerDocs.test.js
@@ -24,7 +24,7 @@ describe('Testing Swagger Documentation', () => {
     await req.get('/research-now/swagger-test')
       .expect(200)
       .then((resp) => {
-        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.2.4')
+        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.2.2')
       })
   })
 

--- a/test/swaggerDocs.test.js
+++ b/test/swaggerDocs.test.js
@@ -21,20 +21,20 @@ describe('Testing Swagger Documentation', () => {
   })
 
   it('test Swagger docs for well formed-ness', async () => {
-    req.get('/research-now/swagger-test')
+    await req.get('/research-now/swagger-test')
       .expect(200)
       .then((resp) => {
-        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.2.3')
+        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.2.4')
       })
   })
 
   it('should return all paths in swagger docs', async () => {
-    req.get('/research-now/swagger')
+    await req.get('/research-now/swagger')
       .expect(200)
       .then((resp) => {
         const apiPaths = []
         Object.keys(resp.body.paths).map(path => apiPaths.push(path))
-        expect(apiPaths.length).to.equal(6)
+        expect(apiPaths.length).to.equal(7)
       })
   })
 })


### PR DESCRIPTION
This adds an additional utility endpoint that provides a simple count of records within the ElasticSearch index. By default this returns a count for only `work` records, but parameters can be provided to display counts for: `instances`, `items`, `links` and `subjects`.