### PR TITLE
SFR-581 fix date range

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -485,8 +485,8 @@ class Search {
             this.logger.debug(`Filtering works by years ${value.start} to ${value.end}`)
             // eslint-disable-next-line no-case-declarations
             const dateRange = {}
-            if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T12:00:00.000+00:00`) }
-            if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T12:00:00.000+00:00`) }
+            if (value.start) { dateRange.gte = new Date(`${value.start}-01-01T00:00:00.000+00:00`) }
+            if (value.end) { dateRange.lte = new Date(`${value.end}-12-31T24:00:00.000+00:00`) }
             dateRange.relation = 'WITHIN'
             yearFilter = ['range', 'instances.pub_date', dateRange]
             this.dateFilterRange = dateRange

--- a/test/v2Search.test.js
+++ b/test/v2Search.test.js
@@ -244,8 +244,8 @@ describe('v2 simple search tests', () => {
       testSearch.addFilters()
       testBody = testSearch.query.build()
       expect(testBody).to.have.property('query')
-      expect(testBody.query.nested.query.bool.must[0].range['instances.pub_date'].gte.getTime()).to.equal(new Date('1900-01-01T12:00:00.000+00:00').getTime())
-      expect(testBody.query.nested.query.bool.must[0].range['instances.pub_date'].lte.getTime()).to.equal(new Date('2000-12-31T12:00:00.000+00:00').getTime())
+      expect(testBody.query.nested.query.bool.must[0].range['instances.pub_date'].gte.getTime()).to.equal(new Date('1900-01-01T00:00:00.000+00:00').getTime())
+      expect(testBody.query.nested.query.bool.must[0].range['instances.pub_date'].lte.getTime()).to.equal(new Date('2000-12-31T24:00:00.000+00:00').getTime())
       done()
     })
 
@@ -258,7 +258,7 @@ describe('v2 simple search tests', () => {
       testSearch.addFilters()
       testBody = testSearch.query.build()
       expect(testBody).to.have.property('query')
-      expect(testBody.query.nested.query.bool.must[0].range['instances.pub_date'].gte.getTime()).to.equal(new Date('1900-01-01T12:00:00.000+00:00').getTime())
+      expect(testBody.query.nested.query.bool.must[0].range['instances.pub_date'].gte.getTime()).to.equal(new Date('1900-01-01T00:00:00.000+00:00').getTime())
       // eslint-disable-next-line no-unused-expressions
       expect(testBody.query.nested.query.bool.must[0].range['instances.pub_date'].lte).to.be.undefined
       done()


### PR DESCRIPTION
When querying date ranges, such as for the publication year filter, ElasticSearch checks to see if the dates fall WITHIN the provided range, including time. To address this all dates are coerced to UTC, including the queried years from the user. However, the user supplied query was setting the search range to begin and end at noon of the first and last day of the supplied year. Internally the dates are set to midnight of December 31st, which caused ElasticSearch to see that the work dates were not within the queried dates and exclude those results.

This fix sets the query date ranges properly to midnight, which should resolve the issue.