### PR TITLE
SFR-661 Add covers subquery to instances and editions

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -254,9 +254,21 @@ class DBConnection {
       .select(this.pg.raw(DBConnection.buildAggString(langFields, 'languages')))
       .as('languages')
 
+    const coverFields = {
+      url: 'url',
+      media_type: 'media_type',
+      flags: 'flags',
+    }
+    const coverSub = this.pg('instance_links')
+      .join('links', 'instance_links.link_id', 'links.id')
+      .where('instance_links.instance_id', this.pg.ref('instances.id'))
+      .where(this.pg.raw('CAST(flags ->> \'cover\' AS BOOLEAN) = true'))
+      .select(this.pg.raw(DBConnection.buildAggString(coverFields, 'covers')))
+      .as('covers')
+
     return this.pg('instances')
       .whereIn('id', instanceIds)
-      .select('*', agentSub, itemSub, langSub)
+      .select('*', agentSub, itemSub, langSub, coverSub)
       .limit(limit)
       .then(rows => rows)
   }
@@ -328,9 +340,22 @@ class DBConnection {
       .select(this.pg.raw(DBConnection.buildAggString(langFields, 'languages')))
       .as('languages')
 
+    const coverFields = {
+      url: 'url',
+      media_type: 'media_type',
+      flags: 'flags',
+    }
+    const coverSub = this.pg('instance_links')
+      .join('links', 'instance_links.link_id', 'links.id')
+      .join('instances', 'instance_links.instance_id', 'links.id')
+      .where('instance_links.instance_id', this.pg.ref('instances.id'))
+      .where(this.pg.raw('CAST(flags ->> \'cover\' AS BOOLEAN) = true'))
+      .select(this.pg.raw(DBConnection.buildAggString(coverFields, 'covers')))
+      .as('covers')
+
     return this.pg('editions')
       .whereIn('id', editionIds)
-      .select('*', langSub, agentSub, itemSub)
+      .select('*', langSub, agentSub, itemSub, coverSub)
       .limit(limit)
       .then(rows => rows)
   }


### PR DESCRIPTION
Adds a subquery to the `links` table for `instances` and `editions` to retrieve any associated covers. This filters on the `flags` column for the presence of a `cover` flag set to `true`