### PR TITLE
Share connections between requests

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,5 +1,3 @@
-const knex = require('knex')
-const mockDB = require('mock-knex')
 
 /**
  * This class manages connections and queries to the PostgreSQL database, which
@@ -8,18 +6,9 @@ const mockDB = require('mock-knex')
  * within the database.
  */
 class DBConnection {
-  constructor(logger) {
+  constructor(logger, dbClient) {
     this.logger = logger
-    if (process.env.NODE_ENV === 'test') {
-      this.pg = knex({ client: 'pg' })
-      mockDB.mock(this.pg)
-    } else {
-      this.pg = knex({
-        client: 'pg',
-        connection: process.env.DB_CONNECTION_STR,
-        pool: { min: 0, max: 10 },
-      })
-    }
+    this.pg = dbClient
   }
 
   /**

--- a/lib/v3Search.js
+++ b/lib/v3Search.js
@@ -38,7 +38,7 @@ class V3Search {
     this.app = app
     this.params = params
     this.logger = this.app.logger
-    this.dbConn = new DBConnection(this.logger)
+    this.dbConn = new DBConnection(this.logger, app.dbClient)
 
     this.show_all_works = false
   }

--- a/lib/v3Work.js
+++ b/lib/v3Work.js
@@ -13,7 +13,7 @@ class V3Work {
     this.app = app
     this.params = params
     this.logger = this.app.logger
-    this.dbConn = new DBConnection(this.logger)
+    this.dbConn = new DBConnection(this.logger, app.dbClient)
   }
 
   /**

--- a/routes/v3/v3.js
+++ b/routes/v3/v3.js
@@ -1,5 +1,7 @@
 const express = require('express')
 const elasticsearch = require('elasticsearch')
+const knex = require('knex')
+const mockDB = require('mock-knex')
 const logger = require('../../lib/logger')
 const pjson = require('../../package.json')
 const { searchEndpoints } = require('./search')
@@ -16,6 +18,18 @@ v3Router.logger = logger
 v3Router.client = new elasticsearch.Client({
   host: process.env.ELASTICSEARCH_HOST,
 })
+
+// Set Database connection
+if (process.env.NODE_ENV === 'test') {
+  v3Router.dbClient = knex({ client: 'pg' })
+  mockDB.mock(this.pg)
+} else {
+  v3Router.dbClient = knex({
+    client: 'pg',
+    connection: process.env.DB_CONNECTION_STR,
+    pool: { min: 0, max: 10 },
+  })
+}
 
 // Status endpoint to verify that v2 is available
 v3Router.get('/', (req, res) => {

--- a/routes/v3/v3.js
+++ b/routes/v3/v3.js
@@ -22,7 +22,7 @@ v3Router.client = new elasticsearch.Client({
 // Set Database connection
 if (process.env.NODE_ENV === 'test') {
   v3Router.dbClient = knex({ client: 'pg' })
-  mockDB.mock(this.pg)
+  mockDB.mock(v3Router.dbClient)
 } else {
   v3Router.dbClient = knex({
     client: 'pg',

--- a/test/dbManager.test.js
+++ b/test/dbManager.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 const chai = require('chai')
+const knex = require('knex')
 const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
 const mockDB = require('mock-knex')
@@ -11,11 +12,14 @@ const { expect } = chai
 
 const { DBConnection } = require('../lib/db')
 
+const testClient = knex({ client: 'pg' })
+mockDB.mock(testClient)
+
 describe('DBConnection manager tests', () => {
   describe('createSubQuery()', () => {
     let testDB
     beforeEach(() => {
-      testDB = new DBConnection(sinon.mock())
+      testDB = new DBConnection(sinon.mock(), testClient)
     })
 
     afterEach(() => {
@@ -34,7 +38,7 @@ describe('DBConnection manager tests', () => {
     let testDB
     const dbTracker = mockDB.getTracker()
     beforeEach(() => {
-      testDB = new DBConnection(sinon.mock())
+      testDB = new DBConnection(sinon.mock(), testClient)
       dbTracker.install()
     })
 


### PR DESCRIPTION
This was creating a new connection pool for every time a new connection was made. This should force the API endpoints a pool of 10 connections, which can be adjusted in the future if its necessary