### PR TITLE
Hotfix front end integrations

### DIFF
--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -123,6 +123,7 @@ const parseAgents = (work, nestedType) => {
 
   const groupAgents = (agents) => {
     const groupedAgents = []
+    // eslint-disable-next-line no-plusplus
     for (let i = 0; i < agents.length; i++) {
       const existing = groupedAgents.find(findMatchingAgent, agents[i])
       if (existing) {
@@ -182,6 +183,7 @@ const parseDates = (work, nestedType) => {
       work.editions[i].publication_date = pubYear
     }
   } else {
+    // eslint-disable-next-line no-plusplus
     for (let i = 0; i < work.instances.length; i++) {
       const pubDate = work.instances[i].dates.find(d => d.date_type === 'publication_date')
       if (pubDate) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -222,6 +222,16 @@ class DBConnection {
     }
     const linkSub = this.createSubQuery('items', 'item_links', 'links', linkFields)
 
+    const rightsFields = {
+      license: 'license',
+      rights_statement: 'rights_statement',
+    }
+    const rightsSub = this.pg('rights')
+      .join('instance_rights', 'instance_rights.rights_id', 'rights.id')
+      .where('instance_rights.instance_id', this.pg.ref('instances.id'))
+      .select(this.pg.raw(DBConnection.buildAggString(rightsFields, 'rights')))
+      .as('rights')
+
     const itemFields = {
       source: 'source',
       content_type: 'content_type',
@@ -257,9 +267,15 @@ class DBConnection {
       .select(this.pg.raw(DBConnection.buildAggString(coverFields, 'covers')))
       .as('covers')
 
+    const dateFields = {
+      display_date: 'display_date',
+      date_type: 'date_type',
+    }
+    const dateSub = this.createSubQuery('instances', 'instance_dates', 'dates', dateFields)
+
     return this.pg('instances')
       .whereIn('id', instanceIds)
-      .select('*', agentSub, itemSub, langSub, coverSub)
+      .select('*', agentSub, itemSub, langSub, coverSub, dateSub, rightsSub)
       .limit(limit)
       .then(rows => rows)
   }

--- a/test/v3Search.test.js
+++ b/test/v3Search.test.js
@@ -511,20 +511,22 @@ describe('v3 simple search tests', () => {
     let testSearch
     let mockParseAgents
     let mockParseLinks
+    let mockParseDates
     beforeEach(() => {
       testSearch = new V3Search(sinon.mock(), {})
       mockParseAgents = sinon.stub(Helpers, 'parseAgents')
       mockParseLinks = sinon.stub(Helpers, 'parseLinks')
+      mockParseDates = sinon.stub(Helpers, 'parseDates')
     })
 
     afterEach(() => {
       mockParseAgents.restore()
       mockParseLinks.restore()
+      mockParseDates.restore()
     })
 
     it('should call getEditions when innerType set to editions', async () => {
       const mockGetEds = sinon.stub(V3Search.prototype, 'getEditions')
-      const mockParseDates = sinon.stub(Helpers, 'parseDates')
       const testWork = {
         instanceIds: [
           {
@@ -541,7 +543,6 @@ describe('v3 simple search tests', () => {
       expect(mockGetEds).to.be.calledOnceWith([1, 2, 3])
       expect(testDBWork.edition_count).to.equal(3)
       mockGetEds.restore()
-      mockParseDates.restore()
     })
 
     it('should call getInstances when innerType set to instances', async () => {


### PR DESCRIPTION
This updates several aspects of the API response to include or update elements in such a way that is more logical or in a way that the front end expects them to be formatted. These updates are:

- Agents now have an array of their `roles` attached. This reduces the duplication of agents in the front end by combining multiple agent objects into a single (this was a side-effect of fetching them from the database)
- Added `rights` and `pub_dates` fields to the `instance` response to retain backwards compatilibility with these front-end layouts