### PR TITLE
SFR-614 Order Editions/Instances

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -274,9 +274,12 @@ class DBConnection {
     }
     const dateSub = this.createSubQuery('instances', 'instance_dates', 'dates', dateFields)
 
+    const sortOrder = `array_position(ARRAY[${instanceIds.join(', ')}], id)`
+
     return this.pg('instances')
       .whereIn('id', instanceIds)
       .select('*', agentSub, itemSub, langSub, coverSub, dateSub, rightsSub)
+      .orderBy(this.pg.raw(sortOrder))
       .limit(limit)
       .then(rows => rows)
   }
@@ -371,9 +374,12 @@ class DBConnection {
       .select(this.pg.raw(DBConnection.buildAggString(coverFields, 'covers')))
       .as('covers')
 
+    const sortOrder = `array_position(ARRAY[${editionIds.join(', ')}], id)`
+
     return this.pg('editions')
       .whereIn('id', editionIds)
       .select('*', langSub, agentSub, itemSub, coverSub)
+      .orderBy(this.pg.raw(sortOrder))
       .limit(limit)
       .then(rows => rows)
   }

--- a/lib/v3Search.js
+++ b/lib/v3Search.js
@@ -59,8 +59,8 @@ class V3Search {
           if (this.reverseResult) resp.hits.hits.reverse()
           V3Search.formatResponsePaging(resp)
           V3Search.formatResponseFacets(resp)
-          const identifiers = V3Search.getInstanceOrEditions(resp)
-          const works = await this.loadWorks(identifiers, this.params.recordType)
+          const identifiers = this.getInstanceOrEditions(resp)
+          const works = await this.loadWorks(identifiers, this.params.recordType, this.params.sort)
           resolve(V3Search.formatResponse(works, resp))
         })
         .catch(error => reject(error))
@@ -202,7 +202,7 @@ class V3Search {
    * @returns {object} A formatted object containing identifiers for retrieval from
    * the database
    */
-  static getInstanceOrEditions(resp) {
+  getInstanceOrEditions(resp) {
     const fetchObjects = []
     /* eslint-disable no-underscore-dangle */
     resp.hits.hits.forEach((hit) => {
@@ -224,6 +224,18 @@ class V3Search {
       } else {
         instances.push(...hit._source.instances)
       }
+
+      const dateSort = this.params.sort ? this.params.sort.find(s => s.field === 'date') : { dir: 'asc' }
+      instances.sort((a, b) => {
+        if (a.pub_date === undefined) return 1
+        if (b.pub_date === undefined) return -1
+        if (dateSort.dir.toLowerCase() === 'desc') {
+          if (a.pub_date.lte < b.pub_date.lte) return 1
+          return -1
+        }
+        if (a.pub_date.gte < b.pub_date.gte) return -1
+        return 1
+      })
 
       instances.forEach((inst) => {
         if ((inst.formats && inst.formats.length > 0)


### PR DESCRIPTION
This returns the editions/instances returned with a search query (depending on the parameters provided) sorted in a way that matches the "parent" sort of the works as exectuted in ElasticSearch.

This is achieved by sorting the `inner_hit` records returned by ElasticSearch with each work (representing matching records) and using the found order as a clause in the Postgres query, enforcing that the order of the supplied array of `id` values is respected and represents the order of the returned rows. This ensures that first/last published versions of a work are what appear in the search results and other behavior.