### PR TITLE
SFR-667 escape lucene search

### DIFF
--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -185,12 +185,14 @@ const parseDates = (work, nestedType) => {
   } else {
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < work.instances.length; i++) {
-      const pubDate = work.instances[i].dates.find(d => d.date_type === 'publication_date')
-      if (pubDate) {
-        work.instances[i].pub_date = pubDate.date_range
-        work.instances[i].pub_date_display = pubDate.display_date
+      if (work.instances[i].dates) {
+        const pubDate = work.instances[i].dates.find(d => d.date_type === 'publication_date')
+        if (pubDate) {
+          work.instances[i].pub_date = pubDate.date_range
+          work.instances[i].pub_date_display = pubDate.display_date
+        }
+        delete work.instances[i].dates
       }
-      delete work.instances[i].dates
     }
   }
 }

--- a/lib/v3Search.js
+++ b/lib/v3Search.js
@@ -228,9 +228,8 @@ class V3Search {
       let dateSort
       if (this.params.sort && this.params.sort.length > 0) {
         dateSort = this.params.sort.find(s => s.field === 'date')
-      } else {
-        dateSort = { dir: 'asc' }
       }
+      if (!dateSort) { dateSort = { dir: 'asc' } }
       instances.sort((a, b) => {
         if (a.pub_date === undefined) return 1
         if (b.pub_date === undefined) return -1

--- a/lib/v3Search.js
+++ b/lib/v3Search.js
@@ -428,6 +428,12 @@ class V3Search {
     this.query.sort(newSort)
   }
 
+  static escapeLucene(query) {
+    // eslint-disable-next-line no-useless-escape
+    const luceneSpecialChars = /[\+\-\&\|\!\(\)\[\]\{\}\^\~\?\:\\]{1,2}/gi
+    return query.replace(luceneSpecialChars, '\\$&')
+  }
+
   /**
    * The manager method for building an ElasticSearch query. This parses the provided
    * parameters and invokes the main query builder, then adds filters, sorting and
@@ -457,7 +463,7 @@ class V3Search {
     }
     queries.forEach((q) => {
       const { field, query } = q
-      this.buildQuery(field, query)
+      this.buildQuery(field, V3Search.escapeLucene(query))
     })
 
     this.queryCount = this.query.build()


### PR DESCRIPTION
ElasticSearch uses the Lucene search syntax to provide a high degree of control over user queries. However the majority of people are not familiar with this and passing these characters in the wrong context can lead to 500 errors from the ES cluster. This provides a regex parser that detects and escapes these characters, with the exception of `AND`, `OR`, `*` and `"` which are all used commonly in boolean search and which do not cause search issues. This should allow users to run the queries they want without restricting their ability to control the search from the search forms.