### PR TITLE
SFR-664 Fix language counts

### DIFF
--- a/lib/v3Search.js
+++ b/lib/v3Search.js
@@ -780,7 +780,7 @@ class V3Search {
   addAggregations() {
     const aggs = []
     // Add aggregation for language facet
-    aggs.push(V3Search.createLangAgg())
+    aggs.push(this.createLangAgg())
 
     aggs.forEach((agg) => {
       this.query.agg(...agg[0], (a) => {
@@ -814,13 +814,13 @@ class V3Search {
    *
    * @returns {Array} The array of aggregation layers to be transformed to an aggregation object
    */
-  static createLangAgg() {
+  createLangAgg() {
     // eslint-disable-next-line no-unused-vars
     let pos = 0
     const langAggOptions = []
     pos = V3Search.addAggLayer(langAggOptions, ['nested', { path: 'instances' }], pos)
 
-    if (this.show_all_works) {
+    if (!this.show_all_works) {
       pos = V3Search.addAggLayer(langAggOptions, ['filter', { exists: { field: 'instances.formats' } }], pos)
     }
 

--- a/routes/v3/utils.js
+++ b/routes/v3/utils.js
@@ -72,7 +72,7 @@ const fetchCounts = async (app, params) => {
     }
   })
   const esQuery = {
-    index: process.env.ELASTICSEARCH_INDEX_V2,
+    index: process.env.ELASTICSEARCH_INDEX_V3,
     body: body.build(),
   }
   const docCounts = await module.exports.execQuery(app, esQuery)
@@ -121,7 +121,7 @@ const fetchLangs = async (app, params) => {
 
   // Create an object that can be understood by the ElasticSearch service
   const esQuery = {
-    index: process.env.ELASTICSEARCH_INDEX_V2,
+    index: process.env.ELASTICSEARCH_INDEX_V3,
     body: body.build(), // Translates bodybuilder object into nested object
   }
 


### PR DESCRIPTION
The function that generates the language aggregation part of the query was a static method, preventing it from accessing the instance variables it needs to accurately create these queries. Changing this, and altering the functionality of the `show_all` filter ensures that this presents accurate information to the user.

To ensure consistency this change has also been reflected in the language utility endpoint.