### PR TITLE
SFR-663 Add true edition count

### DIFF
--- a/lib/v3Search.js
+++ b/lib/v3Search.js
@@ -59,8 +59,11 @@ class V3Search {
           if (this.reverseResult) resp.hits.hits.reverse()
           V3Search.formatResponsePaging(resp)
           V3Search.formatResponseFacets(resp)
-          const identifiers = this.getInstanceOrEditions(resp)
-          const works = await this.loadWorks(identifiers, this.params.recordType, this.params.sort)
+
+          const innerType = this.params.recordType || 'editions'
+
+          const identifiers = this.getInstanceOrEditions(resp, innerType)
+          const works = await this.loadWorks(identifiers, innerType, this.params.sort)
           resolve(V3Search.formatResponse(works, resp))
         })
         .catch(error => reject(error))
@@ -97,9 +100,8 @@ class V3Search {
    *
    * @returns {array} Array of works from the database that can be sent to the end user
    */
-  async loadWorks(works, recordType) {
+  async loadWorks(works, innerType) {
     const outWorks = []
-    const innerType = recordType || 'editions'
     /* eslint-disable no-await-in-loop */
     for (let i = 0; i < works.length; i += 1) {
       const dbWork = await this.getWork(works[i].uuid, ['agents'])
@@ -107,7 +109,7 @@ class V3Search {
         dbWork.sort_title = dbWork.sort_title || works[i].sort_title || dbWork.title.toLowerCase()
         dbWork.instances = null
         dbWork.editions = null
-        dbWork.edition_count = 0
+        dbWork.edition_count = works[i].edition_count
         dbWork.edition_range = works[i].edition_range
         await this.getInnerRecords(works[i], dbWork, innerType)
 
@@ -132,10 +134,8 @@ class V3Search {
   async getInnerRecords(work, dbWork, innerType) {
     const getFunc = `get${innerType.slice(0, 1).toUpperCase()}${innerType.slice(1)}`
     const innerIds = new Set(work.instanceIds.map(ids => ids[`${innerType.slice(0, -1)}_id`]))
-    /* eslint-disable no-param-reassign */
+    // eslint-disable-next-line no-param-reassign
     dbWork[innerType] = await this[getFunc]([...innerIds])
-    dbWork.edition_count = innerIds.size
-    /* eslint-enable no-param-reassign */
     Helpers.parseAgents(dbWork, innerType)
     Helpers.parseLinks(dbWork, innerType)
     Helpers.parseDates(dbWork, innerType)
@@ -202,15 +202,17 @@ class V3Search {
    * @returns {object} A formatted object containing identifiers for retrieval from
    * the database
    */
-  getInstanceOrEditions(resp) {
+  getInstanceOrEditions(resp, recordType) {
     const fetchObjects = []
     /* eslint-disable no-underscore-dangle */
     resp.hits.hits.forEach((hit) => {
+      const edCount = new Set(hit._source.instances.map(inst => inst[`${recordType.slice(0, -1)}_id`]))
       const dbRec = {
         uuid: hit._id,
         sort: hit.sort,
         sort_title: hit._source.sort_title,
         edition_range: Helpers.formatSingleResponseEditionRange(hit),
+        edition_count: edCount.size,
         instanceIds: [],
       }
       const instances = []

--- a/test/v3Search.test.js
+++ b/test/v3Search.test.js
@@ -446,11 +446,13 @@ describe('v3 simple search tests', () => {
       const testWork1 = {
         uuid: 'testUUID1',
         edition_range: '2015-2019',
+        edition_count: 2,
         sort: [1, 2],
       }
       const testWork2 = {
         uuid: 'testUUID2',
         edition_range: '1900-1905',
+        edition_count: 3,
         sort: [3, 4],
       }
       const testWorks = [testWork1, testWork2]
@@ -468,7 +470,7 @@ describe('v3 simple search tests', () => {
           sort_title: 'test1',
           instances: null,
           editions: null,
-          edition_count: 0,
+          edition_count: 2,
           edition_range: '2015-2019',
           sort: [1, 2],
         },
@@ -481,6 +483,7 @@ describe('v3 simple search tests', () => {
       const testWork1 = {
         uuid: 'testUUID1',
         edition_range: '2015-2019',
+        edition_count: 2,
         sort: [1, 2],
       }
       const testWorks = [testWork1]
@@ -497,7 +500,7 @@ describe('v3 simple search tests', () => {
           sort_title: 'testing',
           instances: null,
           editions: null,
-          edition_count: 0,
+          edition_count: 2,
           edition_range: '2015-2019',
           sort: [1, 2],
         },
@@ -541,7 +544,6 @@ describe('v3 simple search tests', () => {
       const testDBWork = {}
       await testSearch.getInnerRecords(testWork, testDBWork, 'editions')
       expect(mockGetEds).to.be.calledOnceWith([1, 2, 3])
-      expect(testDBWork.edition_count).to.equal(3)
       mockGetEds.restore()
     })
 
@@ -561,7 +563,6 @@ describe('v3 simple search tests', () => {
       const testDBWork = {}
       await testSearch.getInnerRecords(testWork, testDBWork, 'instances')
       expect(mockGetInsts).to.be.calledOnceWith([1, 2, 3])
-      expect(testDBWork.edition_count).to.equal(3)
       mockGetInsts.restore()
     })
   })
@@ -625,12 +626,13 @@ describe('v3 simple search tests', () => {
         aggregations: {},
       }
 
-      const fetchObjects = testSearch.getInstanceOrEditions(testResp)
+      const fetchObjects = testSearch.getInstanceOrEditions(testResp, 'editions')
       // eslint-disable-next-line no-unused-expressions
       expect(mockFormatRange).to.be.calledOnce
       expect(fetchObjects[0].uuid).to.equal(1)
       expect(fetchObjects[0].instanceIds[0].instance_id).to.equal(10)
       expect(fetchObjects[0].instanceIds[1].edition_id).to.equal(42)
+      expect(fetchObjects[0].edition_count).to.equal(3)
       done()
     })
 
@@ -677,13 +679,14 @@ describe('v3 simple search tests', () => {
         aggregations: {},
       }
 
-      const fetchObjects = testSearch.getInstanceOrEditions(testResp)
+      const fetchObjects = testSearch.getInstanceOrEditions(testResp, 'editions')
       // eslint-disable-next-line no-unused-expressions
       expect(mockFormatRange).to.be.calledOnce
       expect(fetchObjects[0].uuid).to.equal(1)
       expect(fetchObjects[0].instanceIds.length).to.equal(3)
       expect(fetchObjects[0].instanceIds[0].instance_id).to.equal(10)
       expect(fetchObjects[0].instanceIds[1].edition_id).to.equal(103)
+      expect(fetchObjects[0].edition_count).to.equal(4)
       done()
     })
   })


### PR DESCRIPTION
Previously the edition count being displayed to the user was the number of editions that matched the current filter criteria. This is misleading since it seems to indicate the total number of editions available to view. This counts the number of editions (or instances, if we are in that context) and includes it in the `edition_count` field.