### PR TITLE
HOTFIX handle missing links

### DIFF
--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -152,20 +152,24 @@ const parseAgents = (work, nestedType) => {
 const parseLinks = (work, nestedType) => {
   work[nestedType].forEach((inner) => {
     if (inner.items) {
-      inner.items.forEach((items) => {
-        items.links.forEach((link) => {
-          let flags
-          try {
-            flags = JSON.parse(link.flags)
-          } catch (err) {
-            // eslint-disable-next-line prefer-destructuring
-            flags = link.flags
-          }
-          Object.keys(link.flags).forEach((key) => {
-            link[key] = flags[key]
+      inner.items.forEach((item) => {
+        if (!item.links) {
+          inner.items.pop(item)
+        } else {
+          item.links.forEach((link) => {
+            let flags
+            try {
+              flags = JSON.parse(link.flags)
+            } catch (err) {
+              // eslint-disable-next-line prefer-destructuring
+              flags = link.flags
+            }
+            Object.keys(link.flags).forEach((key) => {
+              link[key] = flags[key]
+            })
+            delete link.flags
           })
-          delete link.flags
-        })
+        }
       })
     }
   })

--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -164,7 +164,7 @@ const parseLinks = (work, nestedType) => {
               // eslint-disable-next-line prefer-destructuring
               flags = link.flags
             }
-            Object.keys(link.flags).forEach((key) => {
+            Object.keys(flags).forEach((key) => {
               link[key] = flags[key]
             })
             delete link.flags

--- a/test/esResponseHelpers.test.js
+++ b/test/esResponseHelpers.test.js
@@ -47,58 +47,92 @@ describe('ElasticSearch Response Parser Helpers', () => {
     })
   })
 
-  it('should get a year for a provided set of editions', (done) => {
-    const stubCompare = sinon.stub(Helpers, 'startEndCompare')
-    const testHit = {
-      _source: {
-        instances: [
-          {
-            pub_date: {
-              gte: '2019-01-01',
-              lte: '2020-12-31',
+  describe('getEditionRangeValue()', () => {
+    it('should get a year for a provided set of editions', (done) => {
+      const stubCompare = sinon.stub(Helpers, 'startEndCompare')
+      const testHit = {
+        _source: {
+          instances: [
+            {
+              pub_date: {
+                gte: '2019-01-01',
+                lte: '2020-12-31',
+              },
+            }, {
+              pub_date: null,
             },
-          }, {
-            pub_date: null,
-          },
-        ],
-      },
-    }
+          ],
+        },
+      }
 
-    const testStart = Helpers.getEditionRangeValue(testHit, 'gte', 1)
-    const testEnd = Helpers.getEditionRangeValue(testHit, 'lte', -1)
-    expect(testStart).to.equal(2019)
-    expect(testEnd).to.equal(2020)
-    stubCompare.restore()
-    done()
+      const testStart = Helpers.getEditionRangeValue(testHit, 'gte', 1)
+      const testEnd = Helpers.getEditionRangeValue(testHit, 'lte', -1)
+      expect(testStart).to.equal(2019)
+      expect(testEnd).to.equal(2020)
+      stubCompare.restore()
+      done()
+    })
+
+    it('should return ???? if no pub date found', (done) => {
+      const stubCompare = sinon.stub(Helpers, 'startEndCompare')
+      const testHit = {
+        _source: {
+          instances: [
+            {
+              pub_date: null,
+            },
+          ],
+        },
+      }
+
+      const testStart = Helpers.getEditionRangeValue(testHit, 'gte', 1)
+      const testEnd = Helpers.getEditionRangeValue(testHit, 'lte', -1)
+      expect(testStart).to.equal('????')
+      expect(testEnd).to.equal('????')
+      stubCompare.restore()
+      done()
+    })
   })
 
-  it('should return ???? if no pub date found', (done) => {
-    const stubCompare = sinon.stub(Helpers, 'startEndCompare')
-    const testHit = {
-      _source: {
-        instances: [
-          {
-            pub_date: null,
-          },
-        ],
-      },
-    }
-
-    const testStart = Helpers.getEditionRangeValue(testHit, 'gte', 1)
-    const testEnd = Helpers.getEditionRangeValue(testHit, 'lte', -1)
-    expect(testStart).to.equal('????')
-    expect(testEnd).to.equal('????')
-    stubCompare.restore()
-    done()
+  describe('startEndCompare()', () => {
+    it('should generate a comparison function for sorting', (done) => {
+      const compareFunction = Helpers.startEndCompare('gte', 1)
+      expect(compareFunction).to.be.instanceOf(Function)
+      const edition1 = { pub_date: { gte: '1999-01-01', lte: null } }
+      const edition2 = { pub_date: { gte: '2000-01-01', lte: null } }
+      const order = compareFunction(edition1, edition2)
+      expect(order).to.equal(-1)
+      done()
+    })
   })
 
-  it('should generate a comparison function for sorting', (done) => {
-    const compareFunction = Helpers.startEndCompare('gte', 1)
-    expect(compareFunction).to.be.instanceOf(Function)
-    const edition1 = { pub_date: { gte: '1999-01-01', lte: null } }
-    const edition2 = { pub_date: { gte: '2000-01-01', lte: null } }
-    const order = compareFunction(edition1, edition2)
-    expect(order).to.equal(-1)
-    done()
+  describe('parseLinks()', () => {
+    let testWork
+
+    beforeEach(() => {
+      testWork = {
+        editions: [{
+          items: [{
+            links: [{
+              url: 'testURL',
+              flags: '{"test": "hello"}',
+            }],
+          }],
+        }],
+      }
+    })
+
+    it('should parse all flags to props', (done) => {
+      Helpers.parseLinks(testWork, 'editions')
+      expect(testWork.editions[0].items[0].links[0].test).to.equal('hello')
+      done()
+    })
+
+    it('should drop any item without any links', (done) => {
+      testWork.editions[0].items[0].links = null
+      Helpers.parseLinks(testWork, 'editions')
+      expect(testWork.editions[0].items.length).to.equal(0)
+      done()
+    })
   })
 })

--- a/test/esResponseHelpers.test.js
+++ b/test/esResponseHelpers.test.js
@@ -10,7 +10,7 @@ chai.use(sinonChai)
 const { expect } = chai
 
 describe('ElasticSearch Response Parser Helpers', () => {
-  describe('getEditionRangeValue()', () => {
+  describe('formatResponseEditionRange()', () => {
     let stubGetRange
     beforeEach(() => {
       stubGetRange = sinon.stub(Helpers, 'getEditionRangeValue')


### PR DESCRIPTION
If an `Item` record is missing links it is an error and should be removed from the response object. This checks for the presence of the `links` array on these objects and `pop`s them from the array if none is found. This handles occasional errors from HathiTrust records where all links were found to be inaccessible, which should be removed at the time, but that cannot be 100% guaranteed. (Errors can cause an exit before a rollback can take place)

This should seamlessly handle these errors, making them invisible to users and preventing any `500`s from being thrown.