### PR TITLE
HOTFIX Filter ALL items without links

### DIFF
--- a/helpers/esSourceHelpers.js
+++ b/helpers/esSourceHelpers.js
@@ -152,10 +152,8 @@ const parseAgents = (work, nestedType) => {
 const parseLinks = (work, nestedType) => {
   work[nestedType].forEach((inner) => {
     if (inner.items) {
-      inner.items.forEach((item, i) => {
-        if (!item.links) {
-          inner.items.slice(i)
-        } else {
+      inner.items.forEach((item) => {
+        if (item.links) {
           item.links.forEach((link) => {
             let flags
             try {
@@ -171,6 +169,7 @@ const parseLinks = (work, nestedType) => {
           })
         }
       })
+      inner.items = inner.items.filter(item => item.links !== null)
     }
   })
 }


### PR DESCRIPTION
This method previously misused `pop` which always removes the final element of an array. This was NOT the correct operation. Instead of applying this logic while parsing the array of items. These are parsed and THEN filtered to remove items without links