### PR TITLE
SFR-692 Add Explicit fields to the keyword search

### DIFF
--- a/lib/v3Search.js
+++ b/lib/v3Search.js
@@ -543,11 +543,51 @@ class V3Search {
       default:
         this.query.query('bool', b => b
           .query('bool', c => c
-            .orQuery('query_string', 'query', queryTerm, { default_operator: 'and' })
-            .orQuery('nested', { path: 'subjects', query: { query_string: { query: queryTerm, default_operator: 'and' } } })
-            .orQuery('nested', { path: 'agents', query: { query_string: { query: queryTerm, default_operator: 'and' } } })
-            .orQuery('nested', { path: 'instances', query: { query_string: { query: queryTerm, default_operator: 'and' } } })
-            .orQuery('nested', { path: 'instances.agents', query: { query_string: { query: queryTerm, default_operator: 'and' } } })))
+            .orQuery('query_string', 'query', queryTerm, {
+              default_operator: 'and',
+              fields: ['title', 'alt_titles', 'series'],
+            })
+            .orQuery('nested', {
+              path: 'subjects',
+              query: {
+                query_string: {
+                  query: queryTerm,
+                  default_operator: 'and',
+                  fields: ['subjects.subject'],
+                },
+              },
+            })
+            .orQuery('nested', {
+              path: 'agents',
+              query: {
+                query_string: {
+                  query: queryTerm,
+                  default_operator: 'and',
+                  field: ['agents.name', 'agents.aliases'],
+                },
+              },
+            })
+            .orQuery('nested', {
+              path: 'instances',
+              query: {
+                query_string: {
+                  query: queryTerm,
+                  default_operator: 'and',
+                  fields: ['instances.title', 'instances.sub_title', 'instances.alt_titles',
+                    'instances.table_of_contents', 'instances.summary', 'instances.volume'],
+                },
+              },
+            })
+            .orQuery('nested', {
+              path: 'instances.agents',
+              query: {
+                query_string: {
+                  query: queryTerm,
+                  default_operator: 'and',
+                  fields: ['instances.agents.name', 'instances.agents.aliases'],
+                },
+              },
+            })))
         break
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,21 +39,23 @@
     "supertest": "^3.4.2"
   },
   "scripts": {
-    "test": "./node_modules/.bin/eslint ./ && NODE_ENV=test ./node_modules/.bin/mocha test --exit",
+    "test": "npm run lint && NODE_ENV=test ./node_modules/.bin/nyc --require mocha npm run run-test",
+    "run-test": "./node_modules/.bin/mocha test --exit",
     "start": "node app.js",
     "start-dev": "nodemon ./app.js localhost 3000",
     "deploy-development": "",
     "deploy-qa": "",
     "deploy-production": "",
     "lint": "./node_modules/.bin/eslint ./",
-    "coverage": "./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls",
+    "coverage": "./node_modules/.bin/nyc report --reporter=text-lcov",
     "coverage:report": "./node_modules/.bin/nyc report --reporter=html && npm run coverage:open-report",
     "coverage:open-report": "open -a 'Google Chrome' ./coverage/index.html"
   },
   "nyc": {
     "exclude": [
       "lib/errors.js",
-      "lib/logger.js"
+      "lib/logger.js",
+      "test/*"
     ]
   },
   "standard": {


### PR DESCRIPTION
JIRA Ticket: https://jira.nypl.org/browse/SFR-692

This adds more specificity to the keyword search option, restricting the queried fields to the ones that are explicity defined in the API. These were decided upon as the fields that were the most likely to be considered to be part of a keyword search by a user.

These can be updated at any time, and should provide the side effect of improving the accuracy of the search relevancy calculation. It may also have an effect on the speed of keyword searches, but small enough that it won't be noticable to the user.